### PR TITLE
improve list table performance by removing onlyLatestSuffix

### DIFF
--- a/langserver/internal/bigquery/mock_bigquery/mock_bigquery.go
+++ b/langserver/internal/bigquery/mock_bigquery/mock_bigquery.go
@@ -155,18 +155,18 @@ func (mr *MockClientMockRecorder) ListProjects(ctx interface{}) *gomock.Call {
 }
 
 // ListTables mocks base method.
-func (m *MockClient) ListTables(ctx context.Context, projectID, datasetID string, onlyLatestSuffix bool) ([]*bigquery.Table, error) {
+func (m *MockClient) ListTables(ctx context.Context, projectID, datasetID string) ([]*bigquery.Table, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListTables", ctx, projectID, datasetID, onlyLatestSuffix)
+	ret := m.ctrl.Call(m, "ListTables", ctx, projectID, datasetID)
 	ret0, _ := ret[0].([]*bigquery.Table)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListTables indicates an expected call of ListTables.
-func (mr *MockClientMockRecorder) ListTables(ctx, projectID, datasetID, onlyLatestSuffix interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) ListTables(ctx, projectID, datasetID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTables", reflect.TypeOf((*MockClient)(nil).ListTables), ctx, projectID, datasetID, onlyLatestSuffix)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTables", reflect.TypeOf((*MockClient)(nil).ListTables), ctx, projectID, datasetID)
 }
 
 // Run mocks base method.
@@ -205,6 +205,21 @@ func NewMockBigqueryJob(ctrl *gomock.Controller) *MockBigqueryJob {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockBigqueryJob) EXPECT() *MockBigqueryJobMockRecorder {
 	return m.recorder
+}
+
+// Config mocks base method.
+func (m *MockBigqueryJob) Config() (bigquery.JobConfig, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Config")
+	ret0, _ := ret[0].(bigquery.JobConfig)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Config indicates an expected call of Config.
+func (mr *MockBigqueryJobMockRecorder) Config() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Config", reflect.TypeOf((*MockBigqueryJob)(nil).Config))
 }
 
 // ID mocks base method.

--- a/langserver/internal/function/builtin_function.go
+++ b/langserver/internal/function/builtin_function.go
@@ -107,7 +107,7 @@ var BuiltInFunctions = []BuiltInFunction{
 	},
 	{
 		Name:        "GROUPING",
-		Method:      "Preview\n  \n    This product or feature is subject to the \"Pre-GA Offerings Terms\"\n    in the General Service Terms section of the\n    Service Specific Terms.\n    Pre-GA products and features are available \"as is\" and might have\n    limited support. For more information, see the\n    launch stage descriptions.",
+		Method:      "GROUPING(groupable_value)",
 		Description: "If a groupable item in the [`GROUP BY` clause](/bigquery/docs/reference/standard-sql/query-syntax#group_by_clause) is aggregated\n(and thus not grouped), this function returns `1`. Otherwise,\nthis function returns `0`.Definitions:`groupable_value`: An expression that represents a value that can be grouped\nin the `GROUP BY` clause.Details:The `GROUPING` function is helpful if you need to determine which rows are\nproduced by which grouping sets. A grouping set is a group of columns by which\nrows can be grouped together. So, if you need to filter rows by\na few specific grouping sets, you can use the `GROUPING` function to identify\nwhich grouping sets grouped which rows by creating a matrix of the results.In addition, you can use the `GROUPING` function to determine the type of\n`NULL` produced by the `GROUP BY` clause. In some cases, the `GROUP BY` clause\nproduces a `NULL` placeholder. This placeholder represents all groupable items\nthat are aggregated (not grouped) in the current grouping set. This is different\nfrom a standard `NULL`, which can also be produced by a query.For more information, see the following examples.",
 		ExampleSQLs: []string{
 			"WITH\n  Products AS (\n    SELECT 'shirt' AS product_type, 't-shirt' AS product_name, 3 AS product_count UNION ALL\n    SELECT 'shirt', 't-shirt', 8 UNION ALL\n    SELECT 'shirt', 'polo', 25 UNION ALL\n    SELECT 'pants', 'jeans', 6\n  )\nSELECT\n  product_type,\n  product_name,\n  SUM(product_count) AS product_sum,\n  GROUPING(product_type) AS product_type_agg,\n  GROUPING(product_name) AS product_name_agg,\nFROM Products\nGROUP BY GROUPING SETS(product_type, product_name, ())\nORDER BY product_name;\n\n/*--------------+--------------+-------------+------------------+------------------+\n | product_type | product_name | product_sum | product_type_agg | product_name_agg |\n +--------------+--------------+-------------+------------------+------------------+\n | NULL         | NULL         | 36          | 1                | 1                |\n | shirt        | NULL         | 36          | 0                | 1                |\n | pants        | NULL         | 6           | 0                | 1                |\n | NULL         | jeans        | 6           | 1                | 0                |\n | NULL         | polo         | 25          | 1                | 0                |\n | NULL         | t-shirt      | 11          | 1                | 0                |\n +--------------+--------------+-------------+------------------+------------------*/",
@@ -347,6 +347,13 @@ var BuiltInFunctions = []BuiltInFunction{
 		Description: "This function returns a transformed object table with the original columns plus\none or more additional columns, depending on the `transform_types` values\nspecified.This function only supports\n[object tables](https://cloud.google.com/bigquery/docs/object-table-introduction)\nas inputs. Subqueries or any other types of tables are not supported.`object_table_name` is the name of the object table to be transformed, in\nthe format `dataset_name.object_table_name`.`transform_types_array` is an array of `STRING` literals. Currently, the only\nsupported `transform_types_array` value is `SIGNED_URL`. Specifying `SIGNED_URL`\ncreates read-only signed URLs for the objects in the identified object table,\nwhich are returned in a `signed_url` column. Generated signed URLs are\nvalid for 6 hours.",
 		ExampleSQLs: []string{},
 		URL:         "https://cloud.google.com/bigquery/docs/reference/standard-sql/table-functions-built-in#external_object_transform",
+	},
+	{
+		Name:        "GAP_FILL",
+		Method:      "Finds and fills gaps in a time series.\nFor more information, see GAP_FILL in\nTime series functions.",
+		Description: "",
+		ExampleSQLs: []string{},
+		URL:         "https://cloud.google.com/bigquery/docs/reference/standard-sql/table-functions-built-in#gap_fill_table_functions",
 	},
 	{
 		Name:        "CAST",

--- a/langserver/internal/source/completion/column_test.go
+++ b/langserver/internal/source/completion/column_test.go
@@ -822,7 +822,7 @@ func TestProject_CompleteColumns(t *testing.T) {
 				}
 				bqClient.EXPECT().GetTableMetadata(gomock.Any(), tablePathSplitted[0], tablePathSplitted[1], tablePathSplitted[2]).Return(schema, nil).MinTimes(0)
 			}
-			bqClient.EXPECT().ListTables(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).MinTimes(0)
+			bqClient.EXPECT().ListTables(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).MinTimes(0)
 			logger := logrus.New()
 			logger.SetLevel(logrus.DebugLevel)
 

--- a/langserver/internal/source/completion/declaration_test.go
+++ b/langserver/internal/source/completion/declaration_test.go
@@ -65,7 +65,7 @@ func TestProject_CompleteDeclaration(t *testing.T) {
 				}
 				bqClient.EXPECT().GetTableMetadata(gomock.Any(), tablePathSplitted[0], tablePathSplitted[1], tablePathSplitted[2]).Return(schema, nil).MinTimes(0)
 			}
-			bqClient.EXPECT().ListTables(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).MinTimes(0)
+			bqClient.EXPECT().ListTables(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).MinTimes(0)
 			logger := logrus.New()
 			logger.SetLevel(logrus.DebugLevel)
 

--- a/langserver/internal/source/completion/table_path.go
+++ b/langserver/internal/source/completion/table_path.go
@@ -107,7 +107,7 @@ func (c *completor) completeDatasetForTablePath(ctx context.Context, param table
 }
 
 func (c *completor) completeTableForTablePath(ctx context.Context, param tablePathParams) ([]CompletionItem, error) {
-	tables, err := c.bqClient.ListTables(ctx, param.ProjectID, param.DatasetID, true)
+	tables, err := c.bqClient.ListTables(ctx, param.ProjectID, param.DatasetID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to bqClient.ListTables: %w", err)
 	}

--- a/langserver/internal/source/completion/table_path_test.go
+++ b/langserver/internal/source/completion/table_path_test.go
@@ -34,7 +34,7 @@ func TestProject_CompleteTablePath(t *testing.T) {
 				ctrl := gomock.NewController(t)
 				bqClient := mock_bigquery.NewMockClient(ctrl)
 
-				bqClient.EXPECT().ListTables(gomock.Any(), "project", "dataset", gomock.Any()).Return([]*bq.Table{
+				bqClient.EXPECT().ListTables(gomock.Any(), "project", "dataset").Return([]*bq.Table{
 					{
 						ProjectID: "project",
 						DatasetID: "dataset",
@@ -76,7 +76,7 @@ func TestProject_CompleteTablePath(t *testing.T) {
 				ctrl := gomock.NewController(t)
 				bqClient := mock_bigquery.NewMockClient(ctrl)
 
-				bqClient.EXPECT().ListTables(gomock.Any(), "project", "dataset", true).Return([]*bq.Table{
+				bqClient.EXPECT().ListTables(gomock.Any(), "project", "dataset").Return([]*bq.Table{
 					{
 						ProjectID: "project",
 						DatasetID: "dataset",

--- a/langserver/internal/source/project.go
+++ b/langserver/internal/source/project.go
@@ -146,7 +146,7 @@ func (p *Project) ListDatasets(ctx context.Context, projectID string) ([]*bq.Dat
 }
 
 func (p *Project) ListTables(ctx context.Context, projectID, datasetID string) ([]*bq.Table, error) {
-	return p.bqClient.ListTables(ctx, projectID, datasetID, true)
+	return p.bqClient.ListTables(ctx, projectID, datasetID)
 }
 
 func (p *Project) ListJobs(ctx context.Context, projectID string, allUsers bool) ([]lsp.JobHistory, error) {


### PR DESCRIPTION
We don't use all table_suffix in bqls. So, I will delete option.