### PR TITLE
fix: only with clause syntax error

### DIFF
--- a/langserver/internal/source/file/analyze.go
+++ b/langserver/internal/source/file/analyze.go
@@ -90,6 +90,9 @@ func (a *Analyzer) ParseFile(uri lsp.DocumentURI, src string) ParsedFile {
 			if strings.Contains(pErr.Msg, "Unexpected end of script") {
 				fixedSrc, pErr, fo = fixUnexpectedEndOfScript(fixedSrc, pErr)
 			}
+			if strings.Contains(pErr.Msg, `Syntax error: Expected "(" or "," or keyword SELECT but got end of script`) {
+				fixedSrc, pErr, fo = fixOnlyWithClauseSyntaxError(fixedSrc, pErr)
+			}
 			errs = append(errs, pErr)
 			if len(fo) > 0 {
 				// retry

--- a/langserver/internal/source/file/file.go
+++ b/langserver/internal/source/file/file.go
@@ -307,6 +307,17 @@ func fixUnexpectedEndOfScript(src string, parsedErr Error) (fixedSrc string, err
 	return src, parsedErr, nil
 }
 
+// `WITH t1 AS (SELECT 1)` return error Expected "(" or "," or keyword SELECT but got end of script
+func fixOnlyWithClauseSyntaxError(src string, parsedErr Error) (fixedSrc string, err Error, fixOffsets []FixOffset) {
+	errOffset := positionToByteOffset(src, parsedErr.Position)
+	return src[:errOffset] + " SELECT 1 " + src[errOffset:], parsedErr, []FixOffset{
+		{
+			Offset: errOffset,
+			Length: len(" SELECT 1 "),
+		},
+	}
+}
+
 // fix Unexpected end of script with deletion
 //
 //	SELECT * FROM table GROUP BY

--- a/langserver/internal/source/file/file_test.go
+++ b/langserver/internal/source/file/file_test.go
@@ -598,6 +598,28 @@ func TestProject_ParseFile(t *testing.T) {
 			},
 			expectedErrs: []file.Error{},
 		},
+		"parse with clause only": {
+			file: "WITH t1 AS (SELECT * FROM `project.dataset.table` t1)\n",
+			bqTableMetadataMap: map[string]*bq.TableMetadata{
+				"project.dataset.table": {
+					Schema: bq.Schema{
+						{
+							Name: "id",
+							Type: bq.IntegerFieldType,
+						},
+					},
+				},
+			},
+			expectedErrs: []file.Error{
+				{
+					Msg: `INVALID_ARGUMENT: Syntax error: Expected "(" or "," or keyword SELECT but got end of script`,
+					Position: lsp.Position{
+						Line:      0,
+						Character: 53,
+					},
+				},
+			},
+		},
 	}
 
 	for n, tt := range tests {


### PR DESCRIPTION
This pull request introduces a new error handling mechanism for a specific SQL syntax error in the `langserver` package. The most important changes include adding a new function to fix the syntax error, updating the main parsing function to utilize this new function, and adding a test case to ensure the new functionality works as expected.

Error handling improvements:

* [`langserver/internal/source/file/analyze.go`](diffhunk://#diff-5b891d3394a701b616f19fabb2bd685176290819841d4aab493e59825a48ad6cR93-R95): Updated the `ParseFile` function to handle the specific syntax error `Syntax error: Expected "(" or "," or keyword SELECT but got end of script` by calling the new `fixOnlyWithClauseSyntaxError` function.

New function addition:

* [`langserver/internal/source/file/file.go`](diffhunk://#diff-6d69b1bc81fc6fe97369cc73f4e1f07fd867ff23c67d073e7603ff6652778688R310-R320): Added the `fixOnlyWithClauseSyntaxError` function to address the specific SQL syntax error by inserting a `SELECT 1` statement at the error position.

Testing enhancements:

* [`langserver/internal/source/file/file_test.go`](diffhunk://#diff-a9e1c90224a9e011237118931c6e6d9b15429c8f9a9a9f3440263ee9fbcaf809R601-R622): Added a new test case `parse with clause only` to verify that the `fixOnlyWithClauseSyntaxError` function correctly handles the specific SQL syntax error.