### PR TITLE
feat: download bqls binary automatically in VSCode extension

### DIFF
--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -10,7 +10,13 @@ Official VSCode extension for [bqls](https://github.com/kitagry/bqls), the BigQu
 
 ## Requirements
 
-Install the `bqls` binary and make sure it's on your `PATH` (or set `bqls.path`).
+On macOS and Linux, the extension downloads a matching `bqls` release from
+GitHub automatically the first time it activates (cached under the
+extension's global storage), so no manual install is required. If `bqls` is
+already on your `PATH` (e.g. via `go install`), that one is used instead.
+
+Windows is not yet supported by the automatic download. Install `bqls`
+manually and point `bqls.path` at it:
 
 ```bash
 go install github.com/kitagry/bqls@latest

--- a/editors/vscode/src/bqlsInstaller.test.ts
+++ b/editors/vscode/src/bqlsInstaller.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it, vi } from "vitest";
+import { InstallerDeps, resolveBqlsCommand } from "./bqlsInstaller";
+import { BQLS_VERSION } from "./bqlsRelease";
+
+function makeDeps(overrides: Partial<InstallerDeps> = {}): InstallerDeps {
+  return {
+    fileExists: vi.fn().mockResolvedValue(false),
+    mkdir: vi.fn().mockResolvedValue(undefined),
+    downloadText: vi.fn().mockResolvedValue(""),
+    downloadFile: vi.fn().mockResolvedValue(undefined),
+    extractTarGz: vi.fn().mockResolvedValue(undefined),
+    chmodExecutable: vi.fn().mockResolvedValue(undefined),
+    sha256File: vi.fn().mockResolvedValue(""),
+    checkOnPath: vi.fn().mockResolvedValue(false),
+    ...overrides,
+  };
+}
+
+const STORAGE_DIR = "/storage";
+
+describe("resolveBqlsCommand", () => {
+  it("trusts an explicitly configured path without touching deps", async () => {
+    const deps = makeDeps();
+
+    const result = await resolveBqlsCommand(
+      "/custom/bqls",
+      STORAGE_DIR,
+      "darwin",
+      "arm64",
+      deps,
+    );
+
+    expect(result).toEqual({ command: "/custom/bqls" });
+    expect(deps.checkOnPath).not.toHaveBeenCalled();
+  });
+
+  it("treats an empty configured path as unset and resolves automatically", async () => {
+    const deps = makeDeps({ checkOnPath: vi.fn().mockResolvedValue(true) });
+
+    const result = await resolveBqlsCommand(
+      "",
+      STORAGE_DIR,
+      "darwin",
+      "arm64",
+      deps,
+    );
+
+    expect(result).toEqual({ command: "bqls" });
+    expect(deps.checkOnPath).toHaveBeenCalledWith("bqls");
+  });
+
+  it("uses bqls from PATH when already installed", async () => {
+    const deps = makeDeps({ checkOnPath: vi.fn().mockResolvedValue(true) });
+
+    const result = await resolveBqlsCommand(
+      "bqls",
+      STORAGE_DIR,
+      "darwin",
+      "arm64",
+      deps,
+    );
+
+    expect(result).toEqual({ command: "bqls" });
+    expect(deps.downloadFile).not.toHaveBeenCalled();
+  });
+
+  it("falls back with an error message on unsupported platforms", async () => {
+    const deps = makeDeps();
+
+    const result = await resolveBqlsCommand(
+      "bqls",
+      STORAGE_DIR,
+      "win32",
+      "x64",
+      deps,
+    );
+
+    expect(result.command).toBe("bqls");
+    expect(result.error).toMatch(/windows/i);
+    expect(deps.downloadFile).not.toHaveBeenCalled();
+  });
+
+  it("reuses an already-cached binary without downloading again", async () => {
+    const deps = makeDeps({ fileExists: vi.fn().mockResolvedValue(true) });
+
+    const result = await resolveBqlsCommand(
+      "bqls",
+      STORAGE_DIR,
+      "darwin",
+      "arm64",
+      deps,
+    );
+
+    expect(result).toEqual({
+      command: `${STORAGE_DIR}/bqls-${BQLS_VERSION}/bqls`,
+    });
+    expect(deps.downloadFile).not.toHaveBeenCalled();
+  });
+
+  it("downloads, verifies checksum, and extracts when nothing is cached", async () => {
+    const sha = "a".repeat(64);
+    const deps = makeDeps({
+      downloadText: vi
+        .fn()
+        .mockResolvedValue(`${sha}  bqls_${BQLS_VERSION}_darwin_arm64.tar.gz`),
+      sha256File: vi.fn().mockResolvedValue(sha),
+    });
+
+    const result = await resolveBqlsCommand(
+      "bqls",
+      STORAGE_DIR,
+      "darwin",
+      "arm64",
+      deps,
+    );
+
+    expect(deps.mkdir).toHaveBeenCalled();
+    expect(deps.downloadFile).toHaveBeenCalledWith(
+      `https://github.com/kitagry/bqls/releases/download/v${BQLS_VERSION}/bqls_${BQLS_VERSION}_darwin_arm64.tar.gz`,
+      expect.any(String),
+    );
+    expect(deps.extractTarGz).toHaveBeenCalled();
+    expect(deps.chmodExecutable).toHaveBeenCalledWith(
+      `${STORAGE_DIR}/bqls-${BQLS_VERSION}/bqls`,
+    );
+    expect(result).toEqual({
+      command: `${STORAGE_DIR}/bqls-${BQLS_VERSION}/bqls`,
+    });
+  });
+
+  it("falls back with an error when the checksum does not match", async () => {
+    const deps = makeDeps({
+      downloadText: vi
+        .fn()
+        .mockResolvedValue(
+          `${"a".repeat(64)}  bqls_${BQLS_VERSION}_darwin_arm64.tar.gz`,
+        ),
+      sha256File: vi.fn().mockResolvedValue("b".repeat(64)),
+    });
+
+    const result = await resolveBqlsCommand(
+      "bqls",
+      STORAGE_DIR,
+      "darwin",
+      "arm64",
+      deps,
+    );
+
+    expect(result.command).toBe("bqls");
+    expect(result.error).toMatch(/checksum/i);
+    expect(deps.extractTarGz).not.toHaveBeenCalled();
+  });
+
+  it("falls back with an error when the download fails", async () => {
+    const deps = makeDeps({
+      downloadText: vi
+        .fn()
+        .mockResolvedValue(
+          `${"a".repeat(64)}  bqls_${BQLS_VERSION}_darwin_arm64.tar.gz`,
+        ),
+      downloadFile: vi.fn().mockRejectedValue(new Error("network error")),
+    });
+
+    const result = await resolveBqlsCommand(
+      "bqls",
+      STORAGE_DIR,
+      "darwin",
+      "arm64",
+      deps,
+    );
+
+    expect(result.command).toBe("bqls");
+    expect(result.error).toMatch(/network error/);
+  });
+});

--- a/editors/vscode/src/bqlsInstaller.ts
+++ b/editors/vscode/src/bqlsInstaller.ts
@@ -1,0 +1,96 @@
+import {
+  BQLS_VERSION,
+  assetFileName,
+  checksumFileName,
+  findSha256,
+  releaseAssetUrl,
+  resolvePlatformTarget,
+} from "./bqlsRelease";
+
+export interface InstallerDeps {
+  fileExists(path: string): Promise<boolean>;
+  mkdir(path: string): Promise<void>;
+  downloadText(url: string): Promise<string>;
+  downloadFile(url: string, destPath: string): Promise<void>;
+  extractTarGz(archivePath: string, destDir: string): Promise<void>;
+  chmodExecutable(path: string): Promise<void>;
+  sha256File(path: string): Promise<string>;
+  checkOnPath(command: string): Promise<boolean>;
+}
+
+export interface ResolveBqlsCommandResult {
+  command: string;
+  error?: string;
+}
+
+const DEFAULT_PATH = "bqls";
+
+function manualInstallFallback(reason: string): ResolveBqlsCommandResult {
+  return {
+    command: DEFAULT_PATH,
+    error: `${reason} Please install bqls manually and set bqls.path.`,
+  };
+}
+
+export async function resolveBqlsCommand(
+  configuredPath: string,
+  storageDir: string,
+  platform: string,
+  arch: string,
+  deps: InstallerDeps,
+): Promise<ResolveBqlsCommandResult> {
+  if (configuredPath && configuredPath !== DEFAULT_PATH) {
+    return { command: configuredPath };
+  }
+
+  if (await deps.checkOnPath(DEFAULT_PATH)) {
+    return { command: DEFAULT_PATH };
+  }
+
+  const target = resolvePlatformTarget(platform, arch);
+  if (!target) {
+    return manualInstallFallback(
+      "Windows is not yet supported for automatic bqls installation.",
+    );
+  }
+
+  const installDir = `${storageDir}/bqls-${BQLS_VERSION}`;
+  const cachedCommand = `${installDir}/bqls`;
+  if (await deps.fileExists(cachedCommand)) {
+    return { command: cachedCommand };
+  }
+
+  const fileName = assetFileName(BQLS_VERSION, target);
+
+  try {
+    const checksumText = await deps.downloadText(
+      releaseAssetUrl(BQLS_VERSION, checksumFileName(BQLS_VERSION)),
+    );
+    const expectedSha = findSha256(checksumText, fileName);
+    if (!expectedSha) {
+      throw new Error(`no checksum found for ${fileName}`);
+    }
+
+    await deps.mkdir(installDir);
+    const archivePath = `${installDir}/${fileName}`;
+    await deps.downloadFile(
+      releaseAssetUrl(BQLS_VERSION, fileName),
+      archivePath,
+    );
+
+    const actualSha = await deps.sha256File(archivePath);
+    if (actualSha !== expectedSha) {
+      throw new Error(
+        `checksum mismatch for ${fileName}: expected ${expectedSha}, got ${actualSha}`,
+      );
+    }
+
+    await deps.extractTarGz(archivePath, installDir);
+    await deps.chmodExecutable(cachedCommand);
+
+    return { command: cachedCommand };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return manualInstallFallback(`Failed to download bqls automatically: ${message}.`);
+  }
+}

--- a/editors/vscode/src/bqlsRelease.test.ts
+++ b/editors/vscode/src/bqlsRelease.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import {
+  BQLS_VERSION,
+  assetFileName,
+  checksumFileName,
+  findSha256,
+  releaseAssetUrl,
+  resolvePlatformTarget,
+} from "./bqlsRelease";
+
+describe("resolvePlatformTarget", () => {
+  it("maps darwin/arm64", () => {
+    expect(resolvePlatformTarget("darwin", "arm64")).toEqual({
+      os: "darwin",
+      arch: "arm64",
+    });
+  });
+
+  it("maps darwin/x64 to amd64", () => {
+    expect(resolvePlatformTarget("darwin", "x64")).toEqual({
+      os: "darwin",
+      arch: "amd64",
+    });
+  });
+
+  it("maps linux/x64 to amd64", () => {
+    expect(resolvePlatformTarget("linux", "x64")).toEqual({
+      os: "linux",
+      arch: "amd64",
+    });
+  });
+
+  it("maps linux/arm64", () => {
+    expect(resolvePlatformTarget("linux", "arm64")).toEqual({
+      os: "linux",
+      arch: "arm64",
+    });
+  });
+
+  it("returns undefined for win32", () => {
+    expect(resolvePlatformTarget("win32", "x64")).toBeUndefined();
+  });
+
+  it("returns undefined for unsupported arch", () => {
+    expect(resolvePlatformTarget("darwin", "ia32")).toBeUndefined();
+  });
+});
+
+describe("assetFileName", () => {
+  it("builds the goreleaser archive name", () => {
+    expect(
+      assetFileName("0.6.0", { os: "darwin", arch: "arm64" }),
+    ).toBe("bqls_0.6.0_darwin_arm64.tar.gz");
+  });
+});
+
+describe("checksumFileName", () => {
+  it("builds the goreleaser checksums file name", () => {
+    expect(checksumFileName("0.6.0")).toBe("bqls_0.6.0_checksums.txt");
+  });
+});
+
+describe("releaseAssetUrl", () => {
+  it("builds the GitHub release download URL", () => {
+    expect(releaseAssetUrl("0.6.0", "bqls_0.6.0_darwin_arm64.tar.gz")).toBe(
+      "https://github.com/kitagry/bqls/releases/download/v0.6.0/bqls_0.6.0_darwin_arm64.tar.gz",
+    );
+  });
+});
+
+describe("findSha256", () => {
+  const checksums = [
+    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  bqls_0.6.0_darwin_amd64.tar.gz",
+    "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb  bqls_0.6.0_darwin_arm64.tar.gz",
+    "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc  bqls_0.6.0_linux_amd64.tar.gz",
+  ].join("\n");
+
+  it("finds the sha256 for a matching file name", () => {
+    expect(findSha256(checksums, "bqls_0.6.0_darwin_arm64.tar.gz")).toBe(
+      "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    );
+  });
+
+  it("returns undefined when the file name is not present", () => {
+    expect(
+      findSha256(checksums, "bqls_0.6.0_windows_amd64.zip"),
+    ).toBeUndefined();
+  });
+});
+
+describe("BQLS_VERSION", () => {
+  it("is a non-empty version string", () => {
+    expect(BQLS_VERSION).toMatch(/^\d+\.\d+\.\d+$/);
+  });
+});

--- a/editors/vscode/src/bqlsRelease.ts
+++ b/editors/vscode/src/bqlsRelease.ts
@@ -1,0 +1,60 @@
+// Pinned bqls version this extension has been tested against. The extension
+// (vscode-v*) and bqls (v*) tags are versioned independently, so this must be
+// bumped by hand whenever the extension needs to rely on a newer bqls release.
+export const BQLS_VERSION = "0.6.0";
+
+export interface PlatformTarget {
+  os: "darwin" | "linux";
+  arch: "amd64" | "arm64";
+}
+
+const OS_MAP: Record<string, PlatformTarget["os"]> = {
+  darwin: "darwin",
+  linux: "linux",
+};
+
+const ARCH_MAP: Record<string, PlatformTarget["arch"]> = {
+  x64: "amd64",
+  arm64: "arm64",
+};
+
+// bqls only ships goreleaser builds for darwin/linux (see .goreleaser.yaml);
+// win32 and other platforms return undefined so callers fall back to manual
+// install.
+export function resolvePlatformTarget(
+  platform: string,
+  arch: string,
+): PlatformTarget | undefined {
+  const os = OS_MAP[platform];
+  const mappedArch = ARCH_MAP[arch];
+  if (!os || !mappedArch) {
+    return undefined;
+  }
+  return { os, arch: mappedArch };
+}
+
+export function assetFileName(version: string, target: PlatformTarget): string {
+  return `bqls_${version}_${target.os}_${target.arch}.tar.gz`;
+}
+
+export function checksumFileName(version: string): string {
+  return `bqls_${version}_checksums.txt`;
+}
+
+export function releaseAssetUrl(version: string, fileName: string): string {
+  return `https://github.com/kitagry/bqls/releases/download/v${version}/${fileName}`;
+}
+
+// goreleaser's checksums.txt uses `sha256(space)(space)filename` lines.
+export function findSha256(
+  checksumText: string,
+  fileName: string,
+): string | undefined {
+  for (const line of checksumText.split("\n")) {
+    const [sha, name] = line.trim().split(/\s+/);
+    if (name === fileName) {
+      return sha;
+    }
+  }
+  return undefined;
+}

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -1,3 +1,9 @@
+import * as crypto from "node:crypto";
+import { execFile } from "node:child_process";
+import * as fs from "node:fs/promises";
+import { createWriteStream } from "node:fs";
+import * as https from "node:https";
+import { promisify } from "node:util";
 import * as vscode from "vscode";
 import {
   LanguageClient,
@@ -5,6 +11,7 @@ import {
   ServerOptions,
   TransportKind,
 } from "vscode-languageclient/node";
+import { InstallerDeps, resolveBqlsCommand } from "./bqlsInstaller";
 import {
   PublishVirtualTextDocumentParams,
   VirtualTextDocumentResult,
@@ -166,6 +173,102 @@ async function handleDefinitionResult(
   return otherLocations as vscode.Definition | vscode.DefinitionLink[];
 }
 
+const execFileAsync = promisify(execFile);
+
+// GitHub release asset downloads respond with a redirect to
+// objects.githubusercontent.com; https.get does not follow redirects itself.
+function httpGetFollowingRedirects(
+  url: string,
+  redirectsLeft = 5,
+): Promise<NodeJS.ReadableStream> {
+  return new Promise((resolve, reject) => {
+    https
+      .get(url, (res) => {
+        const status = res.statusCode ?? 0;
+        if (status >= 300 && status < 400 && res.headers.location) {
+          res.resume();
+          if (redirectsLeft === 0) {
+            reject(new Error(`too many redirects for ${url}`));
+            return;
+          }
+          resolve(httpGetFollowingRedirects(res.headers.location, redirectsLeft - 1));
+          return;
+        }
+        if (status !== 200) {
+          res.resume();
+          reject(new Error(`request to ${url} failed with status ${status}`));
+          return;
+        }
+        resolve(res);
+      })
+      .on("error", reject);
+  });
+}
+
+async function downloadText(url: string): Promise<string> {
+  const stream = await httpGetFollowingRedirects(url);
+  const chunks: Buffer[] = [];
+  for await (const chunk of stream) {
+    chunks.push(chunk as Buffer);
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+async function downloadFile(url: string, destPath: string): Promise<void> {
+  const stream = await httpGetFollowingRedirects(url);
+  await new Promise<void>((resolve, reject) => {
+    const fileStream = createWriteStream(destPath);
+    stream.on("error", reject);
+    fileStream.on("error", reject);
+    fileStream.on("finish", resolve);
+    stream.pipe(fileStream);
+  });
+}
+
+function createNodeInstallerDeps(): InstallerDeps {
+  return {
+    fileExists: async (path) => {
+      try {
+        await fs.access(path);
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    mkdir: async (path) => {
+      await fs.mkdir(path, { recursive: true });
+    },
+    downloadText,
+    downloadFile: async (url, destPath) => {
+      await vscode.window.withProgress(
+        {
+          location: vscode.ProgressLocation.Notification,
+          title: "Downloading bqls...",
+        },
+        () => downloadFile(url, destPath),
+      );
+    },
+    extractTarGz: async (archivePath, destDir) => {
+      await execFileAsync("tar", ["-xzf", archivePath, "-C", destDir]);
+    },
+    chmodExecutable: async (path) => {
+      await fs.chmod(path, 0o755);
+    },
+    sha256File: async (path) => {
+      const data = await fs.readFile(path);
+      return crypto.createHash("sha256").update(data).digest("hex");
+    },
+    checkOnPath: async (command) => {
+      try {
+        await execFileAsync(command, ["--version"]);
+        return true;
+      } catch {
+        return false;
+      }
+    },
+  };
+}
+
 function buildSettings(): {
   project_id: string;
   location: string;
@@ -183,7 +286,17 @@ export async function activate(
   context: vscode.ExtensionContext,
 ): Promise<void> {
   const config = vscode.workspace.getConfiguration("bqls");
-  const command = config.get<string>("path") ?? "bqls";
+  const configuredPath = config.get<string>("path") ?? "bqls";
+  const { command, error } = await resolveBqlsCommand(
+    configuredPath,
+    context.globalStorageUri.fsPath,
+    process.platform,
+    process.arch,
+    createNodeInstallerDeps(),
+  );
+  if (error) {
+    void vscode.window.showWarningMessage(error);
+  }
 
   const serverOptions: ServerOptions = {
     command,


### PR DESCRIPTION
## Summary
- Auto-download a matching `bqls` release from GitHub Releases for macOS/Linux on extension activation, verified via `sha256` from `checksums.txt` and cached under the extension's global storage
- Respect an existing `bqls` on `PATH` (e.g. `go install`) and an explicit non-default `bqls.path` setting without touching the download logic
- Windows keeps the previous manual-install flow (`bqls.path` + `go install`) since bqls has no Windows release build yet; shows a warning message pointing users to manual install
- Update `editors/vscode/README.md` Requirements section accordingly

## Test plan
- [x] `npm run test` (61 tests, including new `bqlsRelease.test.ts` / `bqlsInstaller.test.ts`)
- [x] `npm run compile`
- [x] `npm run lint`
- [x] `npm run build`
- [ ] Manual: launch Extension Development Host (F5) with `bqls` removed from `PATH` and no `bqls.path` override, open a `.sql` file, confirm the download notification appears and hover/completions work afterward
- [ ] Manual: confirm an existing `PATH` install of `bqls` is reused without triggering a download

🤖 Generated with [Claude Code](https://claude.com/claude-code)