### PR TITLE
fix: derive VSCode extension version from release tag

### DIFF
--- a/.github/workflows/vscode-release.yml
+++ b/.github/workflows/vscode-release.yml
@@ -27,14 +27,10 @@ jobs:
       - name: install dependencies
         run: npm ci
 
-      - name: verify tag matches package.json version
+      - name: set version from tag
         run: |
           tag_version="${GITHUB_REF_NAME#vscode-v}"
-          pkg_version="$(node -p "require('./package.json').version")"
-          if [ "$tag_version" != "$pkg_version" ]; then
-            echo "Tag version ($tag_version) does not match package.json version ($pkg_version)"
-            exit 1
-          fi
+          npm version "$tag_version" --no-git-tag-version --allow-same-version
 
       - name: lint
         run: npm run lint


### PR DESCRIPTION
## 背景

`vscode-v0.0.1` タグの push で走った [vscode extension release](https://github.com/kitagry/bqls/actions/runs/30226424189) が失敗した。

```
Tag version (0.0.1) does not match package.json version (0.1.0)
##[error]Process completed with exit code 1.
```

`verify tag matches package.json version` ステップがタグ名と `editors/vscode/package.json` の version の一致を要求していたが、package.json は拡張機能追加時の初期値 `0.1.0` のままだった。publish は実行されていない。

## 変更内容

検証する代わりに、タグから読んだバージョンを package.json に書き込んでから publish するようにした。タグを single source of truth にすることで、リリースのたびに package.json を編集してコミットする手間がなくなる。

```yaml
- name: set version from tag
  run: |
    tag_version="${GITHUB_REF_NAME#vscode-v}"
    npm version "$tag_version" --no-git-tag-version --allow-same-version
```

- `--no-git-tag-version`: CI 内で余計な commit / tag を作らない (タグは既に打たれている)
- `--allow-same-version`: package.json が既に同じバージョンでもエラーにしない
- 不正な semver のタグの場合は `npm version` 自体が落ちるのでバリデーションは維持される
- 後続の `npx vsce publish` は書き換わった package.json を読むので追加変更は不要

## 動作確認

ローカルで `GITHUB_REF_NAME=vscode-v0.0.1` を渡してステップを実行し、`editors/vscode/package.json` の version が `0.0.1` になることを確認した (確認後に package.json / package-lock.json は元に戻してある)。

## マージ後の作業

`vscode-v0.0.1` タグは失敗した run に紐付いたままなので、publish を走らせるにはタグを打ち直す必要がある。

```bash
git tag -d vscode-v0.0.1 && git push origin :refs/tags/vscode-v0.0.1
git tag vscode-v0.0.1 && git push origin vscode-v0.0.1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)