### PR TITLE
chore: CI/GitHub Actions maintenance

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,11 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "npm"
+    directory: "/editors/vscode"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,7 +25,7 @@ jobs:
           cache: true
 
       - name: Install zig
-        uses: goto-bus-stop/setup-zig@v2
+        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
         with:
           version: 0.13.0
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test

--- a/.github/workflows/vscode-release.yml
+++ b/.github/workflows/vscode-release.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - "vscode-v*"
 
+permissions:
+  contents: read
+
 defaults:
   run:
     working-directory: editors/vscode
@@ -18,9 +21,9 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: "20"
+          node-version: "24"
           cache: "npm"
           cache-dependency-path: editors/vscode/package-lock.json
 

--- a/.github/workflows/vscode.yml
+++ b/.github/workflows/vscode.yml
@@ -12,6 +12,9 @@ on:
       - "editors/vscode/**"
       - ".github/workflows/vscode.yml"
 
+permissions:
+  contents: read
+
 defaults:
   run:
     working-directory: editors/vscode
@@ -25,9 +28,9 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: "20"
+          node-version: "24"
           cache: "npm"
           cache-dependency-path: editors/vscode/package-lock.json
 


### PR DESCRIPTION
## Summary
- Added `github-actions` (directory `/`) and `npm` (directory `/editors/vscode`) ecosystems to `.github/dependabot.yml` so Dependabot also monitors Actions and the VSCode extension's npm dependencies
- Replaced the unpinned `goto-bus-stop/setup-zig@v2` in `release.yaml` with `mlugg/setup-zig`, pinned by SHA to match the pinning style used by every other action in the repo
- Declared minimal `permissions: contents: read` on `test.yml`, `vscode.yml`, and `vscode-release.yml`, none of which had permissions declared
- Upgraded `setup-node` from v4.4.0 to v7.0.0 (SHA-pinned) and bumped `node-version` from 20 to 24 accordingly

Closes #339

## Test plan
- [x] Validated YAML syntax for all changed workflow files
- [ ] Confirm CI (test / vscode / release) passes green