### PR TITLE
feat: add ServerInfo (name/version) to LSP initialize response

### DIFF
--- a/langserver/initialize.go
+++ b/langserver/initialize.go
@@ -36,7 +36,15 @@ func (h *Handler) handleInitialize(ctx context.Context, conn *jsonrpc2.Conn, req
 		return nil, err
 	}
 
+	return h.buildInitializeResult(), nil
+}
+
+func (h *Handler) buildInitializeResult() lsp.InitializeResult {
 	return lsp.InitializeResult{
+		ServerInfo: &lsp.ServerInfo{
+			Name:    "bqls",
+			Version: h.version,
+		},
 		Capabilities: lsp.ServerCapabilities{
 			TextDocumentSync: &lsp.TextDocumentSyncOptionsOrKind{
 				Kind: toPtr(lsp.TDSKFull),
@@ -61,7 +69,7 @@ func (h *Handler) handleInitialize(ctx context.Context, conn *jsonrpc2.Conn, req
 				},
 			},
 		},
-	}, nil
+	}
 }
 
 func toPtr[T any](s T) *T {

--- a/langserver/initialize_test.go
+++ b/langserver/initialize_test.go
@@ -3,6 +3,8 @@ package langserver
 import (
 	"encoding/json"
 	"testing"
+
+	"github.com/kitagry/bqls/langserver/internal/lsp"
 )
 
 func TestInitializeOption_SupportsAsyncVirtualTextDocument(t *testing.T) {
@@ -28,6 +30,50 @@ func TestInitializeOption_SupportsAsyncVirtualTextDocument(t *testing.T) {
 			}
 			if got.SupportsAsyncVirtualTextDocument != tt.expected {
 				t.Errorf("SupportsAsyncVirtualTextDocument = %v, want %v", got.SupportsAsyncVirtualTextDocument, tt.expected)
+			}
+		})
+	}
+}
+
+func TestHandler_buildInitializeResult_ServerInfo(t *testing.T) {
+	h := &Handler{version: "v1.2.3"}
+
+	result := h.buildInitializeResult()
+
+	if result.ServerInfo == nil {
+		t.Fatal("ServerInfo is nil, want non-nil")
+	}
+	if result.ServerInfo.Name != "bqls" {
+		t.Errorf("ServerInfo.Name = %q, want %q", result.ServerInfo.Name, "bqls")
+	}
+	if result.ServerInfo.Version != "v1.2.3" {
+		t.Errorf("ServerInfo.Version = %q, want %q", result.ServerInfo.Version, "v1.2.3")
+	}
+}
+
+func TestServerInfo_JSON(t *testing.T) {
+	tests := map[string]struct {
+		info lsp.ServerInfo
+		want string
+	}{
+		"with version": {
+			info: lsp.ServerInfo{Name: "bqls", Version: "v1.2.3"},
+			want: `{"name":"bqls","version":"v1.2.3"}`,
+		},
+		"version omitted when empty": {
+			info: lsp.ServerInfo{Name: "bqls"},
+			want: `{"name":"bqls"}`,
+		},
+	}
+
+	for n, tt := range tests {
+		t.Run(n, func(t *testing.T) {
+			got, err := json.Marshal(tt.info)
+			if err != nil {
+				t.Fatalf("failed to marshal: %v", err)
+			}
+			if string(got) != tt.want {
+				t.Errorf("json = %s, want %s", got, tt.want)
 			}
 		})
 	}

--- a/langserver/internal/lsp/service.go
+++ b/langserver/internal/lsp/service.go
@@ -214,6 +214,12 @@ type WindowClientCapabilities struct {
 
 type InitializeResult struct {
 	Capabilities ServerCapabilities `json:"capabilities,omitempty"`
+	ServerInfo   *ServerInfo        `json:"serverInfo,omitempty"`
+}
+
+type ServerInfo struct {
+	Name    string `json:"name"`
+	Version string `json:"version,omitempty"`
 }
 
 type InitializeError struct {

--- a/langserver/langserver.go
+++ b/langserver/langserver.go
@@ -22,8 +22,9 @@ type jsonrpcConn interface {
 }
 
 type Handler struct {
-	conn   jsonrpcConn
-	logger *logrus.Logger
+	conn    jsonrpcConn
+	logger  *logrus.Logger
+	version string
 
 	bqClient bigquery.Client
 	project  *source.Project
@@ -36,7 +37,7 @@ type Handler struct {
 
 var _ jsonrpc2.Handler = (*Handler)(nil)
 
-func NewHandler(isDebug bool) *Handler {
+func NewHandler(isDebug bool, version string) *Handler {
 	logger := logrus.New()
 	logger.Out = os.Stderr
 	if isDebug {
@@ -47,6 +48,7 @@ func NewHandler(isDebug bool) *Handler {
 
 	handler := &Handler{
 		logger:                     logger,
+		version:                    version,
 		diagnosticRequest:          make(chan lsp.DocumentURI, 3),
 		dryrunRequest:              make(chan lsp.DocumentURI, 3),
 		virtualTextDocumentRequest: make(chan lsp.DocumentURI, 3),

--- a/main.go
+++ b/main.go
@@ -68,7 +68,7 @@ You can use your favorite lsp client.
 		return exitCodeErr
 	}
 
-	handler := langserver.NewHandler(*isDebug)
+	handler := langserver.NewHandler(*isDebug, version)
 	defer handler.Close()
 	<-jsonrpc2.NewConn(context.Background(), jsonrpc2.NewBufferedStream(stdrwc{}, jsonrpc2.VSCodeObjectCodec{}), handler).DisconnectNotify()
 	return exitCodeOK


### PR DESCRIPTION
## Summary
- Implement the LSP-standard `InitializeResult.serverInfo` (name/version) field so the running bqls version can be read directly from the `initialize` response
- Extend `langserver.NewHandler` to accept a version, and thread the same value used by `main.go`'s `--version` flag (embedded via `-X main.version={{.Tag}}` at release time) into the initialize response

## Motivation
There was a request from bqls.nvim to detect the running bqls server version. The existing `bqls --version` CLI flag requires spawning a separate process outside the LSP protocol, which doesn't fit this use case, so this properly implements the LSP-standard ServerInfo instead.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...` passes
- [x] Added test cases in `langserver/initialize_test.go` covering ServerInfo content and JSON serialization (implemented via TDD)