### PR TITLE
Ignore $/-prefixed notifications and condense recache error logs

### DIFF
--- a/langserver/handle_test.go
+++ b/langserver/handle_test.go
@@ -1,0 +1,60 @@
+package langserver
+
+import (
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/sourcegraph/jsonrpc2"
+)
+
+func TestHandler_handle_dollarPrefixedMethods(t *testing.T) {
+	tests := map[string]struct {
+		method    string
+		notif     bool
+		wantError bool
+	}{
+		"$/setTrace notification is ignored": {
+			method:    "$/setTrace",
+			notif:     true,
+			wantError: false,
+		},
+		"unknown $/ notification is ignored": {
+			method:    "$/cancelRequest",
+			notif:     true,
+			wantError: false,
+		},
+		"unknown $/ request still errors": {
+			method:    "$/unknownRequest",
+			notif:     false,
+			wantError: true,
+		},
+		"unknown non-$/ method still errors": {
+			method:    "unknown/method",
+			notif:     false,
+			wantError: true,
+		},
+	}
+
+	for n, tt := range tests {
+		t.Run(n, func(t *testing.T) {
+			h := &Handler{logger: logrus.New()}
+			req := &jsonrpc2.Request{Method: tt.method, Notif: tt.notif}
+
+			got, err := h.handle(t.Context(), nil, req)
+
+			if tt.wantError {
+				if err == nil {
+					t.Fatalf("handle() error = nil, want error for method %q", tt.method)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("handle() error = %v, want nil for method %q", err, tt.method)
+			}
+			if got != nil {
+				t.Errorf("handle() result = %v, want nil for method %q", got, tt.method)
+			}
+		})
+	}
+}

--- a/langserver/internal/bigquery/cache.go
+++ b/langserver/internal/bigquery/cache.go
@@ -9,7 +9,19 @@ import (
 
 	"cloud.google.com/go/bigquery"
 	"google.golang.org/api/cloudresourcemanager/v1"
+	"google.golang.org/api/googleapi"
 )
+
+// formatCacheError condenses a googleapi.Error down to its code and message,
+// dropping the nested Details/Body fields that would otherwise dump a large
+// JSON blob to the log for what is a non-fatal, background recache failure.
+func formatCacheError(err error) string {
+	var apiErr *googleapi.Error
+	if errors.As(err, &apiErr) {
+		return fmt.Sprintf("googleapi: %d: %s", apiErr.Code, apiErr.Message)
+	}
+	return err.Error()
+}
 
 type cache struct {
 	Client
@@ -59,7 +71,7 @@ func (c *cache) ListProjects(ctx context.Context) ([]*cloudresourcemanager.Proje
 			ctx := context.WithoutCancel(ctx)
 			_, err := c.callListProjects(ctx)
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "failed to recache projects: %v\n", err)
+				fmt.Fprintf(os.Stderr, "failed to recache projects: %s\n", formatCacheError(err))
 			}
 		})
 		return results, nil
@@ -102,7 +114,7 @@ func (c *cache) ListDatasets(ctx context.Context, projectID string) ([]*bigquery
 			ctx := context.WithoutCancel(ctx)
 			_, err := c.callListDatasets(ctx, projectID)
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "failed to recache datasets: %v\n", err)
+				fmt.Fprintf(os.Stderr, "failed to recache datasets: %s\n", formatCacheError(err))
 			}
 		})
 		return results, nil
@@ -143,7 +155,7 @@ func (c *cache) ListTables(ctx context.Context, projectID, datasetID string) ([]
 			ctx := context.WithoutCancel(ctx)
 			_, err := c.callListTables(ctx, projectID, datasetID)
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "failed to recache tables: %v\n", err)
+				fmt.Fprintf(os.Stderr, "failed to recache tables: %s\n", formatCacheError(err))
 			}
 		})
 

--- a/langserver/internal/bigquery/cache_error_test.go
+++ b/langserver/internal/bigquery/cache_error_test.go
@@ -1,0 +1,43 @@
+package bigquery
+
+import (
+	"errors"
+	"testing"
+
+	"google.golang.org/api/googleapi"
+)
+
+func TestFormatCacheError(t *testing.T) {
+	tests := map[string]struct {
+		err      error
+		expected string
+	}{
+		"googleapi.Error is condensed to code and message, dropping nested Details": {
+			err: &googleapi.Error{
+				Code:    403,
+				Message: "Cloud Resource Manager API has not been used in project kitagry before or it is disabled.",
+				Details: []interface{}{
+					map[string]interface{}{"@type": "type.googleapis.com/google.rpc.ErrorInfo", "reason": "SERVICE_DISABLED"},
+				},
+			},
+			expected: "googleapi: 403: Cloud Resource Manager API has not been used in project kitagry before or it is disabled.",
+		},
+		"wrapped googleapi.Error is also condensed": {
+			err:      errors.Join(&googleapi.Error{Code: 500, Message: "internal error"}),
+			expected: "googleapi: 500: internal error",
+		},
+		"non googleapi.Error falls back to err.Error()": {
+			err:      errors.New("some other error"),
+			expected: "some other error",
+		},
+	}
+
+	for n, tt := range tests {
+		t.Run(n, func(t *testing.T) {
+			got := formatCacheError(tt.err)
+			if got != tt.expected {
+				t.Errorf("formatCacheError() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}

--- a/langserver/langserver.go
+++ b/langserver/langserver.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"runtime/debug"
+	"strings"
 
 	"github.com/kitagry/bqls/langserver/internal/bigquery"
 	"github.com/kitagry/bqls/langserver/internal/lsp"
@@ -134,6 +135,13 @@ func (h *Handler) handle(ctx context.Context, conn *jsonrpc2.Conn, req *jsonrpc2
 		return h.handleWorkspaceDidChangeConfiguration(ctx, conn, req)
 	case "bqls/virtualTextDocument":
 		return h.handleVirtualTextDocument(ctx, conn, req)
+	}
+	// Per the LSP spec, "$/"-prefixed notifications (e.g. $/setTrace,
+	// $/cancelRequest) are protocol-implementation-dependent and may be
+	// freely ignored by servers that don't implement them; only "$/"
+	// requests must still be errored with MethodNotFound.
+	if req.Notif && strings.HasPrefix(req.Method, "$/") {
+		return nil, nil
 	}
 	return nil, &jsonrpc2.Error{Code: jsonrpc2.CodeMethodNotFound, Message: fmt.Sprintf("method not supported: %s", req.Method)}
 }


### PR DESCRIPTION
## Summary
- `$/setTrace` (and any other `$/`-prefixed notification, e.g. `$/cancelRequest`) was falling through `handle()`'s switch to `MethodNotFound`, spamming the log every time a client connects. Per the LSP spec, servers may freely ignore `$/`-prefixed notifications they don't implement, while `$/`-prefixed *requests* must still error — so this is handled generically rather than adding a one-off `$/setTrace` case.
- Background recache failures in `cache.go` (`ListProjects`/`ListDatasets`/`ListTables`) dumped the full `googleapi.Error` — including nested `Details` JSON — to stderr, even though the request itself still succeeds by returning cached data. Added a `formatCacheError` helper that condenses `*googleapi.Error` down to just its code and message for a one-line warning; other errors still print via `err.Error()`.

## Test plan
- [x] Added `TestHandler_handle_dollarPrefixedMethods` covering `$/setTrace` and other `$/` notifications (ignored), `$/`-prefixed requests (still error), and non-`$/` unknown methods (still error)
- [x] Added `TestFormatCacheError` covering plain `*googleapi.Error`, a wrapped one, and a non-googleapi error
- [x] `go build ./...` and `go vet ./...`
- [x] `go test ./...` (all packages pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)