### PR TITLE
editors/vscode: enable biome formatter and add format script

### DIFF
--- a/.github/workflows/vscode.yml
+++ b/.github/workflows/vscode.yml
@@ -40,6 +40,9 @@ jobs:
       - name: lint
         run: npm run lint
 
+      - name: format check
+        run: npm run format
+
       - name: type check
         run: npm run compile
 

--- a/editors/vscode/biome.json
+++ b/editors/vscode/biome.json
@@ -2,7 +2,7 @@
 	"$schema": "https://biomejs.dev/schemas/2.5.6/schema.json",
 	"vcs": { "enabled": true, "clientKind": "git", "useIgnoreFile": true },
 	"files": { "includes": ["**", "!!**/dist"] },
-	"formatter": { "enabled": false },
+	"formatter": { "enabled": true },
 	"linter": {
 		"enabled": true,
 		"rules": { "recommended": true }

--- a/editors/vscode/esbuild.js
+++ b/editors/vscode/esbuild.js
@@ -4,27 +4,27 @@ const production = process.argv.includes("--production");
 const watch = process.argv.includes("--watch");
 
 async function main() {
-  const ctx = await esbuild.context({
-    entryPoints: ["src/extension.ts"],
-    bundle: true,
-    format: "cjs",
-    minify: production,
-    sourcemap: !production,
-    platform: "node",
-    outfile: "dist/extension.js",
-    external: ["vscode"],
-    logLevel: "info",
-  });
+	const ctx = await esbuild.context({
+		entryPoints: ["src/extension.ts"],
+		bundle: true,
+		format: "cjs",
+		minify: production,
+		sourcemap: !production,
+		platform: "node",
+		outfile: "dist/extension.js",
+		external: ["vscode"],
+		logLevel: "info",
+	});
 
-  if (watch) {
-    await ctx.watch();
-  } else {
-    await ctx.rebuild();
-    await ctx.dispose();
-  }
+	if (watch) {
+		await ctx.watch();
+	} else {
+		await ctx.rebuild();
+		await ctx.dispose();
+	}
 }
 
 main().catch((err) => {
-  console.error(err);
-  process.exit(1);
+	console.error(err);
+	process.exit(1);
 });

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -1,162 +1,164 @@
 {
-  "name": "bqls",
-  "displayName": "bqls",
-  "description": "BigQuery language server client for VSCode",
-  "version": "0.1.0",
-  "publisher": "kitagry",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/kitagry/bqls"
-  },
-  "license": "MIT",
-  "engines": {
-    "vscode": "^1.85.0"
-  },
-  "categories": [
-    "Programming Languages"
-  ],
-  "activationEvents": [
-    "onLanguage:sql"
-  ],
-  "main": "./dist/extension.js",
-  "contributes": {
-    "languages": [
-      {
-        "id": "sql",
-        "extensions": [
-          ".sql",
-          ".bq"
-        ]
-      }
-    ],
-    "viewsContainers": {
-      "activitybar": [
-        {
-          "id": "bqls",
-          "title": "BigQuery",
-          "icon": "media/bqls.svg"
-        }
-      ]
-    },
-    "views": {
-      "bqls": [
-        {
-          "id": "bqlsDatasetExplorer",
-          "name": "Datasets"
-        }
-      ]
-    },
-    "commands": [
-      {
-        "command": "bqls.addProjectToExplorer",
-        "title": "Add Project…",
-        "icon": "$(add)",
-        "category": "BigQuery"
-      },
-      {
-        "command": "bqls.refreshDatasetExplorer",
-        "title": "Refresh",
-        "icon": "$(refresh)",
-        "category": "BigQuery"
-      },
-      {
-        "command": "bqls.searchTablesInExplorer",
-        "title": "Search Tables",
-        "icon": "$(search)",
-        "category": "BigQuery"
-      },
-      {
-        "command": "bqls.removeProjectFromExplorer",
-        "title": "Remove from BigQuery Explorer",
-        "icon": "$(trash)",
-        "category": "BigQuery"
-      }
-    ],
-    "menus": {
-      "view/title": [
-        {
-          "command": "bqls.addProjectToExplorer",
-          "when": "view == bqlsDatasetExplorer",
-          "group": "navigation"
-        },
-        {
-          "command": "bqls.refreshDatasetExplorer",
-          "when": "view == bqlsDatasetExplorer",
-          "group": "navigation"
-        },
-        {
-          "command": "bqls.searchTablesInExplorer",
-          "when": "view == bqlsDatasetExplorer",
-          "group": "navigation"
-        }
-      ],
-      "view/item/context": [
-        {
-          "command": "bqls.removeProjectFromExplorer",
-          "when": "view == bqlsDatasetExplorer && viewItem == bqlsProject"
-        }
-      ]
-    },
-    "configuration": {
-      "type": "object",
-      "title": "bqls",
-      "properties": {
-        "bqls.path": {
-          "type": "string",
-          "default": "bqls",
-          "description": "Path to the bqls executable."
-        },
-        "bqls.projectId": {
-          "type": "string",
-          "default": "",
-          "description": "BigQuery project ID. If empty, bqls uses `gcloud config get project`."
-        },
-        "bqls.projectIds": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "default": [],
-          "description": "BigQuery project IDs shown in the Datasets explorer view. Add more via the \"+\" button on the view, or edit this list directly. Independent of bqls.projectId."
-        },
-        "bqls.location": {
-          "type": "string",
-          "default": "",
-          "description": "BigQuery location (e.g. US, asia-northeast1). If empty, bqls uses \"US\"."
-        },
-        "bqls.trace.server": {
-          "type": "string",
-          "enum": [
-            "off",
-            "messages",
-            "verbose"
-          ],
-          "default": "off",
-          "description": "Trace communication between VSCode and the bqls language server."
-        }
-      }
-    }
-  },
-  "scripts": {
-    "vscode:prepublish": "npm run build",
-    "build": "node esbuild.js --production",
-    "watch": "node esbuild.js --watch",
-    "compile": "tsc --noEmit -p ./",
-    "lint": "biome lint src",
-    "test": "vitest run",
-    "package": "vsce package",
-    "publish": "vsce publish"
-  },
-  "dependencies": {
-    "vscode-languageclient": "^9.0.1"
-  },
-  "devDependencies": {
-    "@biomejs/biome": "^2.5.6",
-    "@types/node": "^26.1.2",
-    "@types/vscode": "^1.85.0",
-    "@vscode/vsce": "^3.9.2",
-    "esbuild": "^0.28.1",
-    "typescript": "^7.0.2",
-    "vitest": "^4.1.10"
-  }
+	"name": "bqls",
+	"displayName": "bqls",
+	"description": "BigQuery language server client for VSCode",
+	"version": "0.1.0",
+	"publisher": "kitagry",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/kitagry/bqls"
+	},
+	"license": "MIT",
+	"engines": {
+		"vscode": "^1.85.0"
+	},
+	"categories": [
+		"Programming Languages"
+	],
+	"activationEvents": [
+		"onLanguage:sql"
+	],
+	"main": "./dist/extension.js",
+	"contributes": {
+		"languages": [
+			{
+				"id": "sql",
+				"extensions": [
+					".sql",
+					".bq"
+				]
+			}
+		],
+		"viewsContainers": {
+			"activitybar": [
+				{
+					"id": "bqls",
+					"title": "BigQuery",
+					"icon": "media/bqls.svg"
+				}
+			]
+		},
+		"views": {
+			"bqls": [
+				{
+					"id": "bqlsDatasetExplorer",
+					"name": "Datasets"
+				}
+			]
+		},
+		"commands": [
+			{
+				"command": "bqls.addProjectToExplorer",
+				"title": "Add Project…",
+				"icon": "$(add)",
+				"category": "BigQuery"
+			},
+			{
+				"command": "bqls.refreshDatasetExplorer",
+				"title": "Refresh",
+				"icon": "$(refresh)",
+				"category": "BigQuery"
+			},
+			{
+				"command": "bqls.searchTablesInExplorer",
+				"title": "Search Tables",
+				"icon": "$(search)",
+				"category": "BigQuery"
+			},
+			{
+				"command": "bqls.removeProjectFromExplorer",
+				"title": "Remove from BigQuery Explorer",
+				"icon": "$(trash)",
+				"category": "BigQuery"
+			}
+		],
+		"menus": {
+			"view/title": [
+				{
+					"command": "bqls.addProjectToExplorer",
+					"when": "view == bqlsDatasetExplorer",
+					"group": "navigation"
+				},
+				{
+					"command": "bqls.refreshDatasetExplorer",
+					"when": "view == bqlsDatasetExplorer",
+					"group": "navigation"
+				},
+				{
+					"command": "bqls.searchTablesInExplorer",
+					"when": "view == bqlsDatasetExplorer",
+					"group": "navigation"
+				}
+			],
+			"view/item/context": [
+				{
+					"command": "bqls.removeProjectFromExplorer",
+					"when": "view == bqlsDatasetExplorer && viewItem == bqlsProject"
+				}
+			]
+		},
+		"configuration": {
+			"type": "object",
+			"title": "bqls",
+			"properties": {
+				"bqls.path": {
+					"type": "string",
+					"default": "bqls",
+					"description": "Path to the bqls executable."
+				},
+				"bqls.projectId": {
+					"type": "string",
+					"default": "",
+					"description": "BigQuery project ID. If empty, bqls uses `gcloud config get project`."
+				},
+				"bqls.projectIds": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					},
+					"default": [],
+					"description": "BigQuery project IDs shown in the Datasets explorer view. Add more via the \"+\" button on the view, or edit this list directly. Independent of bqls.projectId."
+				},
+				"bqls.location": {
+					"type": "string",
+					"default": "",
+					"description": "BigQuery location (e.g. US, asia-northeast1). If empty, bqls uses \"US\"."
+				},
+				"bqls.trace.server": {
+					"type": "string",
+					"enum": [
+						"off",
+						"messages",
+						"verbose"
+					],
+					"default": "off",
+					"description": "Trace communication between VSCode and the bqls language server."
+				}
+			}
+		}
+	},
+	"scripts": {
+		"vscode:prepublish": "npm run build",
+		"build": "node esbuild.js --production",
+		"watch": "node esbuild.js --watch",
+		"compile": "tsc --noEmit -p ./",
+		"lint": "biome lint src",
+		"format": "biome format .",
+		"format:fix": "biome format --write .",
+		"test": "vitest run",
+		"package": "vsce package",
+		"publish": "vsce publish"
+	},
+	"dependencies": {
+		"vscode-languageclient": "^9.0.1"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "^2.5.6",
+		"@types/node": "^26.1.2",
+		"@types/vscode": "^1.85.0",
+		"@vscode/vsce": "^3.9.2",
+		"esbuild": "^0.28.1",
+		"typescript": "^7.0.2",
+		"vitest": "^4.1.10"
+	}
 }

--- a/editors/vscode/src/bqlsInstaller.test.ts
+++ b/editors/vscode/src/bqlsInstaller.test.ts
@@ -3,173 +3,173 @@ import { InstallerDeps, resolveBqlsCommand } from "./bqlsInstaller";
 import { BQLS_VERSION } from "./bqlsRelease";
 
 function makeDeps(overrides: Partial<InstallerDeps> = {}): InstallerDeps {
-  return {
-    fileExists: vi.fn().mockResolvedValue(false),
-    mkdir: vi.fn().mockResolvedValue(undefined),
-    downloadText: vi.fn().mockResolvedValue(""),
-    downloadFile: vi.fn().mockResolvedValue(undefined),
-    extractTarGz: vi.fn().mockResolvedValue(undefined),
-    chmodExecutable: vi.fn().mockResolvedValue(undefined),
-    sha256File: vi.fn().mockResolvedValue(""),
-    checkOnPath: vi.fn().mockResolvedValue(false),
-    ...overrides,
-  };
+	return {
+		fileExists: vi.fn().mockResolvedValue(false),
+		mkdir: vi.fn().mockResolvedValue(undefined),
+		downloadText: vi.fn().mockResolvedValue(""),
+		downloadFile: vi.fn().mockResolvedValue(undefined),
+		extractTarGz: vi.fn().mockResolvedValue(undefined),
+		chmodExecutable: vi.fn().mockResolvedValue(undefined),
+		sha256File: vi.fn().mockResolvedValue(""),
+		checkOnPath: vi.fn().mockResolvedValue(false),
+		...overrides,
+	};
 }
 
 const STORAGE_DIR = "/storage";
 
 describe("resolveBqlsCommand", () => {
-  it("trusts an explicitly configured path without touching deps", async () => {
-    const deps = makeDeps();
+	it("trusts an explicitly configured path without touching deps", async () => {
+		const deps = makeDeps();
 
-    const result = await resolveBqlsCommand(
-      "/custom/bqls",
-      STORAGE_DIR,
-      "darwin",
-      "arm64",
-      deps,
-    );
+		const result = await resolveBqlsCommand(
+			"/custom/bqls",
+			STORAGE_DIR,
+			"darwin",
+			"arm64",
+			deps,
+		);
 
-    expect(result).toEqual({ command: "/custom/bqls" });
-    expect(deps.checkOnPath).not.toHaveBeenCalled();
-  });
+		expect(result).toEqual({ command: "/custom/bqls" });
+		expect(deps.checkOnPath).not.toHaveBeenCalled();
+	});
 
-  it("treats an empty configured path as unset and resolves automatically", async () => {
-    const deps = makeDeps({ checkOnPath: vi.fn().mockResolvedValue(true) });
+	it("treats an empty configured path as unset and resolves automatically", async () => {
+		const deps = makeDeps({ checkOnPath: vi.fn().mockResolvedValue(true) });
 
-    const result = await resolveBqlsCommand(
-      "",
-      STORAGE_DIR,
-      "darwin",
-      "arm64",
-      deps,
-    );
+		const result = await resolveBqlsCommand(
+			"",
+			STORAGE_DIR,
+			"darwin",
+			"arm64",
+			deps,
+		);
 
-    expect(result).toEqual({ command: "bqls" });
-    expect(deps.checkOnPath).toHaveBeenCalledWith("bqls");
-  });
+		expect(result).toEqual({ command: "bqls" });
+		expect(deps.checkOnPath).toHaveBeenCalledWith("bqls");
+	});
 
-  it("uses bqls from PATH when already installed", async () => {
-    const deps = makeDeps({ checkOnPath: vi.fn().mockResolvedValue(true) });
+	it("uses bqls from PATH when already installed", async () => {
+		const deps = makeDeps({ checkOnPath: vi.fn().mockResolvedValue(true) });
 
-    const result = await resolveBqlsCommand(
-      "bqls",
-      STORAGE_DIR,
-      "darwin",
-      "arm64",
-      deps,
-    );
+		const result = await resolveBqlsCommand(
+			"bqls",
+			STORAGE_DIR,
+			"darwin",
+			"arm64",
+			deps,
+		);
 
-    expect(result).toEqual({ command: "bqls" });
-    expect(deps.downloadFile).not.toHaveBeenCalled();
-  });
+		expect(result).toEqual({ command: "bqls" });
+		expect(deps.downloadFile).not.toHaveBeenCalled();
+	});
 
-  it("falls back with an error message on unsupported platforms", async () => {
-    const deps = makeDeps();
+	it("falls back with an error message on unsupported platforms", async () => {
+		const deps = makeDeps();
 
-    const result = await resolveBqlsCommand(
-      "bqls",
-      STORAGE_DIR,
-      "win32",
-      "x64",
-      deps,
-    );
+		const result = await resolveBqlsCommand(
+			"bqls",
+			STORAGE_DIR,
+			"win32",
+			"x64",
+			deps,
+		);
 
-    expect(result.command).toBe("bqls");
-    expect(result.error).toMatch(/windows/i);
-    expect(deps.downloadFile).not.toHaveBeenCalled();
-  });
+		expect(result.command).toBe("bqls");
+		expect(result.error).toMatch(/windows/i);
+		expect(deps.downloadFile).not.toHaveBeenCalled();
+	});
 
-  it("reuses an already-cached binary without downloading again", async () => {
-    const deps = makeDeps({ fileExists: vi.fn().mockResolvedValue(true) });
+	it("reuses an already-cached binary without downloading again", async () => {
+		const deps = makeDeps({ fileExists: vi.fn().mockResolvedValue(true) });
 
-    const result = await resolveBqlsCommand(
-      "bqls",
-      STORAGE_DIR,
-      "darwin",
-      "arm64",
-      deps,
-    );
+		const result = await resolveBqlsCommand(
+			"bqls",
+			STORAGE_DIR,
+			"darwin",
+			"arm64",
+			deps,
+		);
 
-    expect(result).toEqual({
-      command: `${STORAGE_DIR}/bqls-${BQLS_VERSION}/bqls`,
-    });
-    expect(deps.downloadFile).not.toHaveBeenCalled();
-  });
+		expect(result).toEqual({
+			command: `${STORAGE_DIR}/bqls-${BQLS_VERSION}/bqls`,
+		});
+		expect(deps.downloadFile).not.toHaveBeenCalled();
+	});
 
-  it("downloads, verifies checksum, and extracts when nothing is cached", async () => {
-    const sha = "a".repeat(64);
-    const deps = makeDeps({
-      downloadText: vi
-        .fn()
-        .mockResolvedValue(`${sha}  bqls_${BQLS_VERSION}_darwin_arm64.tar.gz`),
-      sha256File: vi.fn().mockResolvedValue(sha),
-    });
+	it("downloads, verifies checksum, and extracts when nothing is cached", async () => {
+		const sha = "a".repeat(64);
+		const deps = makeDeps({
+			downloadText: vi
+				.fn()
+				.mockResolvedValue(`${sha}  bqls_${BQLS_VERSION}_darwin_arm64.tar.gz`),
+			sha256File: vi.fn().mockResolvedValue(sha),
+		});
 
-    const result = await resolveBqlsCommand(
-      "bqls",
-      STORAGE_DIR,
-      "darwin",
-      "arm64",
-      deps,
-    );
+		const result = await resolveBqlsCommand(
+			"bqls",
+			STORAGE_DIR,
+			"darwin",
+			"arm64",
+			deps,
+		);
 
-    expect(deps.mkdir).toHaveBeenCalled();
-    expect(deps.downloadFile).toHaveBeenCalledWith(
-      `https://github.com/kitagry/bqls/releases/download/v${BQLS_VERSION}/bqls_${BQLS_VERSION}_darwin_arm64.tar.gz`,
-      expect.any(String),
-    );
-    expect(deps.extractTarGz).toHaveBeenCalled();
-    expect(deps.chmodExecutable).toHaveBeenCalledWith(
-      `${STORAGE_DIR}/bqls-${BQLS_VERSION}/bqls`,
-    );
-    expect(result).toEqual({
-      command: `${STORAGE_DIR}/bqls-${BQLS_VERSION}/bqls`,
-    });
-  });
+		expect(deps.mkdir).toHaveBeenCalled();
+		expect(deps.downloadFile).toHaveBeenCalledWith(
+			`https://github.com/kitagry/bqls/releases/download/v${BQLS_VERSION}/bqls_${BQLS_VERSION}_darwin_arm64.tar.gz`,
+			expect.any(String),
+		);
+		expect(deps.extractTarGz).toHaveBeenCalled();
+		expect(deps.chmodExecutable).toHaveBeenCalledWith(
+			`${STORAGE_DIR}/bqls-${BQLS_VERSION}/bqls`,
+		);
+		expect(result).toEqual({
+			command: `${STORAGE_DIR}/bqls-${BQLS_VERSION}/bqls`,
+		});
+	});
 
-  it("falls back with an error when the checksum does not match", async () => {
-    const deps = makeDeps({
-      downloadText: vi
-        .fn()
-        .mockResolvedValue(
-          `${"a".repeat(64)}  bqls_${BQLS_VERSION}_darwin_arm64.tar.gz`,
-        ),
-      sha256File: vi.fn().mockResolvedValue("b".repeat(64)),
-    });
+	it("falls back with an error when the checksum does not match", async () => {
+		const deps = makeDeps({
+			downloadText: vi
+				.fn()
+				.mockResolvedValue(
+					`${"a".repeat(64)}  bqls_${BQLS_VERSION}_darwin_arm64.tar.gz`,
+				),
+			sha256File: vi.fn().mockResolvedValue("b".repeat(64)),
+		});
 
-    const result = await resolveBqlsCommand(
-      "bqls",
-      STORAGE_DIR,
-      "darwin",
-      "arm64",
-      deps,
-    );
+		const result = await resolveBqlsCommand(
+			"bqls",
+			STORAGE_DIR,
+			"darwin",
+			"arm64",
+			deps,
+		);
 
-    expect(result.command).toBe("bqls");
-    expect(result.error).toMatch(/checksum/i);
-    expect(deps.extractTarGz).not.toHaveBeenCalled();
-  });
+		expect(result.command).toBe("bqls");
+		expect(result.error).toMatch(/checksum/i);
+		expect(deps.extractTarGz).not.toHaveBeenCalled();
+	});
 
-  it("falls back with an error when the download fails", async () => {
-    const deps = makeDeps({
-      downloadText: vi
-        .fn()
-        .mockResolvedValue(
-          `${"a".repeat(64)}  bqls_${BQLS_VERSION}_darwin_arm64.tar.gz`,
-        ),
-      downloadFile: vi.fn().mockRejectedValue(new Error("network error")),
-    });
+	it("falls back with an error when the download fails", async () => {
+		const deps = makeDeps({
+			downloadText: vi
+				.fn()
+				.mockResolvedValue(
+					`${"a".repeat(64)}  bqls_${BQLS_VERSION}_darwin_arm64.tar.gz`,
+				),
+			downloadFile: vi.fn().mockRejectedValue(new Error("network error")),
+		});
 
-    const result = await resolveBqlsCommand(
-      "bqls",
-      STORAGE_DIR,
-      "darwin",
-      "arm64",
-      deps,
-    );
+		const result = await resolveBqlsCommand(
+			"bqls",
+			STORAGE_DIR,
+			"darwin",
+			"arm64",
+			deps,
+		);
 
-    expect(result.command).toBe("bqls");
-    expect(result.error).toMatch(/network error/);
-  });
+		expect(result.command).toBe("bqls");
+		expect(result.error).toMatch(/network error/);
+	});
 });

--- a/editors/vscode/src/bqlsInstaller.ts
+++ b/editors/vscode/src/bqlsInstaller.ts
@@ -1,96 +1,98 @@
 import {
-  BQLS_VERSION,
-  assetFileName,
-  checksumFileName,
-  findSha256,
-  releaseAssetUrl,
-  resolvePlatformTarget,
+	BQLS_VERSION,
+	assetFileName,
+	checksumFileName,
+	findSha256,
+	releaseAssetUrl,
+	resolvePlatformTarget,
 } from "./bqlsRelease";
 
 export interface InstallerDeps {
-  fileExists(path: string): Promise<boolean>;
-  mkdir(path: string): Promise<void>;
-  downloadText(url: string): Promise<string>;
-  downloadFile(url: string, destPath: string): Promise<void>;
-  extractTarGz(archivePath: string, destDir: string): Promise<void>;
-  chmodExecutable(path: string): Promise<void>;
-  sha256File(path: string): Promise<string>;
-  checkOnPath(command: string): Promise<boolean>;
+	fileExists(path: string): Promise<boolean>;
+	mkdir(path: string): Promise<void>;
+	downloadText(url: string): Promise<string>;
+	downloadFile(url: string, destPath: string): Promise<void>;
+	extractTarGz(archivePath: string, destDir: string): Promise<void>;
+	chmodExecutable(path: string): Promise<void>;
+	sha256File(path: string): Promise<string>;
+	checkOnPath(command: string): Promise<boolean>;
 }
 
 export interface ResolveBqlsCommandResult {
-  command: string;
-  error?: string;
+	command: string;
+	error?: string;
 }
 
 const DEFAULT_PATH = "bqls";
 
 function manualInstallFallback(reason: string): ResolveBqlsCommandResult {
-  return {
-    command: DEFAULT_PATH,
-    error: `${reason} Please install bqls manually and set bqls.path.`,
-  };
+	return {
+		command: DEFAULT_PATH,
+		error: `${reason} Please install bqls manually and set bqls.path.`,
+	};
 }
 
 export async function resolveBqlsCommand(
-  configuredPath: string,
-  storageDir: string,
-  platform: string,
-  arch: string,
-  deps: InstallerDeps,
+	configuredPath: string,
+	storageDir: string,
+	platform: string,
+	arch: string,
+	deps: InstallerDeps,
 ): Promise<ResolveBqlsCommandResult> {
-  if (configuredPath && configuredPath !== DEFAULT_PATH) {
-    return { command: configuredPath };
-  }
+	if (configuredPath && configuredPath !== DEFAULT_PATH) {
+		return { command: configuredPath };
+	}
 
-  if (await deps.checkOnPath(DEFAULT_PATH)) {
-    return { command: DEFAULT_PATH };
-  }
+	if (await deps.checkOnPath(DEFAULT_PATH)) {
+		return { command: DEFAULT_PATH };
+	}
 
-  const target = resolvePlatformTarget(platform, arch);
-  if (!target) {
-    return manualInstallFallback(
-      "Windows is not yet supported for automatic bqls installation.",
-    );
-  }
+	const target = resolvePlatformTarget(platform, arch);
+	if (!target) {
+		return manualInstallFallback(
+			"Windows is not yet supported for automatic bqls installation.",
+		);
+	}
 
-  const installDir = `${storageDir}/bqls-${BQLS_VERSION}`;
-  const cachedCommand = `${installDir}/bqls`;
-  if (await deps.fileExists(cachedCommand)) {
-    return { command: cachedCommand };
-  }
+	const installDir = `${storageDir}/bqls-${BQLS_VERSION}`;
+	const cachedCommand = `${installDir}/bqls`;
+	if (await deps.fileExists(cachedCommand)) {
+		return { command: cachedCommand };
+	}
 
-  const fileName = assetFileName(BQLS_VERSION, target);
+	const fileName = assetFileName(BQLS_VERSION, target);
 
-  try {
-    const checksumText = await deps.downloadText(
-      releaseAssetUrl(BQLS_VERSION, checksumFileName(BQLS_VERSION)),
-    );
-    const expectedSha = findSha256(checksumText, fileName);
-    if (!expectedSha) {
-      throw new Error(`no checksum found for ${fileName}`);
-    }
+	try {
+		const checksumText = await deps.downloadText(
+			releaseAssetUrl(BQLS_VERSION, checksumFileName(BQLS_VERSION)),
+		);
+		const expectedSha = findSha256(checksumText, fileName);
+		if (!expectedSha) {
+			throw new Error(`no checksum found for ${fileName}`);
+		}
 
-    await deps.mkdir(installDir);
-    const archivePath = `${installDir}/${fileName}`;
-    await deps.downloadFile(
-      releaseAssetUrl(BQLS_VERSION, fileName),
-      archivePath,
-    );
+		await deps.mkdir(installDir);
+		const archivePath = `${installDir}/${fileName}`;
+		await deps.downloadFile(
+			releaseAssetUrl(BQLS_VERSION, fileName),
+			archivePath,
+		);
 
-    const actualSha = await deps.sha256File(archivePath);
-    if (actualSha !== expectedSha) {
-      throw new Error(
-        `checksum mismatch for ${fileName}: expected ${expectedSha}, got ${actualSha}`,
-      );
-    }
+		const actualSha = await deps.sha256File(archivePath);
+		if (actualSha !== expectedSha) {
+			throw new Error(
+				`checksum mismatch for ${fileName}: expected ${expectedSha}, got ${actualSha}`,
+			);
+		}
 
-    await deps.extractTarGz(archivePath, installDir);
-    await deps.chmodExecutable(cachedCommand);
+		await deps.extractTarGz(archivePath, installDir);
+		await deps.chmodExecutable(cachedCommand);
 
-    return { command: cachedCommand };
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    return manualInstallFallback(`Failed to download bqls automatically: ${message}.`);
-  }
+		return { command: cachedCommand };
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		return manualInstallFallback(
+			`Failed to download bqls automatically: ${message}.`,
+		);
+	}
 }

--- a/editors/vscode/src/bqlsRelease.test.ts
+++ b/editors/vscode/src/bqlsRelease.test.ts
@@ -1,95 +1,95 @@
 import { describe, expect, it } from "vitest";
 import {
-  BQLS_VERSION,
-  assetFileName,
-  checksumFileName,
-  findSha256,
-  releaseAssetUrl,
-  resolvePlatformTarget,
+	BQLS_VERSION,
+	assetFileName,
+	checksumFileName,
+	findSha256,
+	releaseAssetUrl,
+	resolvePlatformTarget,
 } from "./bqlsRelease";
 
 describe("resolvePlatformTarget", () => {
-  it("maps darwin/arm64", () => {
-    expect(resolvePlatformTarget("darwin", "arm64")).toEqual({
-      os: "darwin",
-      arch: "arm64",
-    });
-  });
+	it("maps darwin/arm64", () => {
+		expect(resolvePlatformTarget("darwin", "arm64")).toEqual({
+			os: "darwin",
+			arch: "arm64",
+		});
+	});
 
-  it("maps darwin/x64 to amd64", () => {
-    expect(resolvePlatformTarget("darwin", "x64")).toEqual({
-      os: "darwin",
-      arch: "amd64",
-    });
-  });
+	it("maps darwin/x64 to amd64", () => {
+		expect(resolvePlatformTarget("darwin", "x64")).toEqual({
+			os: "darwin",
+			arch: "amd64",
+		});
+	});
 
-  it("maps linux/x64 to amd64", () => {
-    expect(resolvePlatformTarget("linux", "x64")).toEqual({
-      os: "linux",
-      arch: "amd64",
-    });
-  });
+	it("maps linux/x64 to amd64", () => {
+		expect(resolvePlatformTarget("linux", "x64")).toEqual({
+			os: "linux",
+			arch: "amd64",
+		});
+	});
 
-  it("maps linux/arm64", () => {
-    expect(resolvePlatformTarget("linux", "arm64")).toEqual({
-      os: "linux",
-      arch: "arm64",
-    });
-  });
+	it("maps linux/arm64", () => {
+		expect(resolvePlatformTarget("linux", "arm64")).toEqual({
+			os: "linux",
+			arch: "arm64",
+		});
+	});
 
-  it("returns undefined for win32", () => {
-    expect(resolvePlatformTarget("win32", "x64")).toBeUndefined();
-  });
+	it("returns undefined for win32", () => {
+		expect(resolvePlatformTarget("win32", "x64")).toBeUndefined();
+	});
 
-  it("returns undefined for unsupported arch", () => {
-    expect(resolvePlatformTarget("darwin", "ia32")).toBeUndefined();
-  });
+	it("returns undefined for unsupported arch", () => {
+		expect(resolvePlatformTarget("darwin", "ia32")).toBeUndefined();
+	});
 });
 
 describe("assetFileName", () => {
-  it("builds the goreleaser archive name", () => {
-    expect(
-      assetFileName("0.6.0", { os: "darwin", arch: "arm64" }),
-    ).toBe("bqls_0.6.0_darwin_arm64.tar.gz");
-  });
+	it("builds the goreleaser archive name", () => {
+		expect(assetFileName("0.6.0", { os: "darwin", arch: "arm64" })).toBe(
+			"bqls_0.6.0_darwin_arm64.tar.gz",
+		);
+	});
 });
 
 describe("checksumFileName", () => {
-  it("builds the goreleaser checksums file name", () => {
-    expect(checksumFileName("0.6.0")).toBe("bqls_0.6.0_checksums.txt");
-  });
+	it("builds the goreleaser checksums file name", () => {
+		expect(checksumFileName("0.6.0")).toBe("bqls_0.6.0_checksums.txt");
+	});
 });
 
 describe("releaseAssetUrl", () => {
-  it("builds the GitHub release download URL", () => {
-    expect(releaseAssetUrl("0.6.0", "bqls_0.6.0_darwin_arm64.tar.gz")).toBe(
-      "https://github.com/kitagry/bqls/releases/download/v0.6.0/bqls_0.6.0_darwin_arm64.tar.gz",
-    );
-  });
+	it("builds the GitHub release download URL", () => {
+		expect(releaseAssetUrl("0.6.0", "bqls_0.6.0_darwin_arm64.tar.gz")).toBe(
+			"https://github.com/kitagry/bqls/releases/download/v0.6.0/bqls_0.6.0_darwin_arm64.tar.gz",
+		);
+	});
 });
 
 describe("findSha256", () => {
-  const checksums = [
-    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  bqls_0.6.0_darwin_amd64.tar.gz",
-    "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb  bqls_0.6.0_darwin_arm64.tar.gz",
-    "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc  bqls_0.6.0_linux_amd64.tar.gz",
-  ].join("\n");
+	const checksums = [
+		"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  bqls_0.6.0_darwin_amd64.tar.gz",
+		"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb  bqls_0.6.0_darwin_arm64.tar.gz",
+		"cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc  bqls_0.6.0_linux_amd64.tar.gz",
+	].join("\n");
 
-  it("finds the sha256 for a matching file name", () => {
-    expect(findSha256(checksums, "bqls_0.6.0_darwin_arm64.tar.gz")).toBe(
-      "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-    );
-  });
+	it("finds the sha256 for a matching file name", () => {
+		expect(findSha256(checksums, "bqls_0.6.0_darwin_arm64.tar.gz")).toBe(
+			"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		);
+	});
 
-  it("returns undefined when the file name is not present", () => {
-    expect(
-      findSha256(checksums, "bqls_0.6.0_windows_amd64.zip"),
-    ).toBeUndefined();
-  });
+	it("returns undefined when the file name is not present", () => {
+		expect(
+			findSha256(checksums, "bqls_0.6.0_windows_amd64.zip"),
+		).toBeUndefined();
+	});
 });
 
 describe("BQLS_VERSION", () => {
-  it("is a non-empty version string", () => {
-    expect(BQLS_VERSION).toMatch(/^\d+\.\d+\.\d+$/);
-  });
+	it("is a non-empty version string", () => {
+		expect(BQLS_VERSION).toMatch(/^\d+\.\d+\.\d+$/);
+	});
 });

--- a/editors/vscode/src/bqlsRelease.ts
+++ b/editors/vscode/src/bqlsRelease.ts
@@ -4,57 +4,57 @@
 export const BQLS_VERSION = "0.6.0";
 
 export interface PlatformTarget {
-  os: "darwin" | "linux";
-  arch: "amd64" | "arm64";
+	os: "darwin" | "linux";
+	arch: "amd64" | "arm64";
 }
 
 const OS_MAP: Record<string, PlatformTarget["os"]> = {
-  darwin: "darwin",
-  linux: "linux",
+	darwin: "darwin",
+	linux: "linux",
 };
 
 const ARCH_MAP: Record<string, PlatformTarget["arch"]> = {
-  x64: "amd64",
-  arm64: "arm64",
+	x64: "amd64",
+	arm64: "arm64",
 };
 
 // bqls only ships goreleaser builds for darwin/linux (see .goreleaser.yaml);
 // win32 and other platforms return undefined so callers fall back to manual
 // install.
 export function resolvePlatformTarget(
-  platform: string,
-  arch: string,
+	platform: string,
+	arch: string,
 ): PlatformTarget | undefined {
-  const os = OS_MAP[platform];
-  const mappedArch = ARCH_MAP[arch];
-  if (!os || !mappedArch) {
-    return undefined;
-  }
-  return { os, arch: mappedArch };
+	const os = OS_MAP[platform];
+	const mappedArch = ARCH_MAP[arch];
+	if (!os || !mappedArch) {
+		return undefined;
+	}
+	return { os, arch: mappedArch };
 }
 
 export function assetFileName(version: string, target: PlatformTarget): string {
-  return `bqls_${version}_${target.os}_${target.arch}.tar.gz`;
+	return `bqls_${version}_${target.os}_${target.arch}.tar.gz`;
 }
 
 export function checksumFileName(version: string): string {
-  return `bqls_${version}_checksums.txt`;
+	return `bqls_${version}_checksums.txt`;
 }
 
 export function releaseAssetUrl(version: string, fileName: string): string {
-  return `https://github.com/kitagry/bqls/releases/download/v${version}/${fileName}`;
+	return `https://github.com/kitagry/bqls/releases/download/v${version}/${fileName}`;
 }
 
 // goreleaser's checksums.txt uses `sha256(space)(space)filename` lines.
 export function findSha256(
-  checksumText: string,
-  fileName: string,
+	checksumText: string,
+	fileName: string,
 ): string | undefined {
-  for (const line of checksumText.split("\n")) {
-    const [sha, name] = line.trim().split(/\s+/);
-    if (name === fileName) {
-      return sha;
-    }
-  }
-  return undefined;
+	for (const line of checksumText.split("\n")) {
+		const [sha, name] = line.trim().split(/\s+/);
+		if (name === fileName) {
+			return sha;
+		}
+	}
+	return undefined;
 }

--- a/editors/vscode/src/commandResultHandler.test.ts
+++ b/editors/vscode/src/commandResultHandler.test.ts
@@ -1,56 +1,59 @@
 import { describe, expect, it } from "vitest";
-import { isExternalUrl, jobHistoryQuickPickItems } from "./commandResultHandler";
+import {
+	isExternalUrl,
+	jobHistoryQuickPickItems,
+} from "./commandResultHandler";
 
 describe("isExternalUrl", () => {
-  it("returns true for an http url", () => {
-    expect(isExternalUrl("http://example.com/sheet")).toBe(true);
-  });
+	it("returns true for an http url", () => {
+		expect(isExternalUrl("http://example.com/sheet")).toBe(true);
+	});
 
-  it("returns true for an https url", () => {
-    expect(isExternalUrl("https://docs.google.com/spreadsheets/d/abc")).toBe(
-      true,
-    );
-  });
+	it("returns true for an https url", () => {
+		expect(isExternalUrl("https://docs.google.com/spreadsheets/d/abc")).toBe(
+			true,
+		);
+	});
 
-  it("returns false for a local file path", () => {
-    expect(isExternalUrl("/Users/foo/Downloads/1.csv")).toBe(false);
-  });
+	it("returns false for a local file path", () => {
+		expect(isExternalUrl("/Users/foo/Downloads/1.csv")).toBe(false);
+	});
 });
 
 describe("jobHistoryQuickPickItems", () => {
-  it("maps jobs to quick pick items keyed by job uri", () => {
-    const items = jobHistoryQuickPickItems({
-      jobs: [
-        {
-          textDocument: { uri: "bqls://project/job1" },
-          id: "job1",
-          owner: "alice@example.com",
-          summary: "SELECT 1",
-        },
-        {
-          textDocument: { uri: "bqls://project/job2" },
-          id: "job2",
-          owner: "bob@example.com",
-          summary: "SELECT 2",
-        },
-      ],
-    });
+	it("maps jobs to quick pick items keyed by job uri", () => {
+		const items = jobHistoryQuickPickItems({
+			jobs: [
+				{
+					textDocument: { uri: "bqls://project/job1" },
+					id: "job1",
+					owner: "alice@example.com",
+					summary: "SELECT 1",
+				},
+				{
+					textDocument: { uri: "bqls://project/job2" },
+					id: "job2",
+					owner: "bob@example.com",
+					summary: "SELECT 2",
+				},
+			],
+		});
 
-    expect(items).toEqual([
-      {
-        label: "SELECT 1",
-        description: "alice@example.com",
-        uri: "bqls://project/job1",
-      },
-      {
-        label: "SELECT 2",
-        description: "bob@example.com",
-        uri: "bqls://project/job2",
-      },
-    ]);
-  });
+		expect(items).toEqual([
+			{
+				label: "SELECT 1",
+				description: "alice@example.com",
+				uri: "bqls://project/job1",
+			},
+			{
+				label: "SELECT 2",
+				description: "bob@example.com",
+				uri: "bqls://project/job2",
+			},
+		]);
+	});
 
-  it("returns an empty array when there are no jobs", () => {
-    expect(jobHistoryQuickPickItems({ jobs: [] })).toEqual([]);
-  });
+	it("returns an empty array when there are no jobs", () => {
+		expect(jobHistoryQuickPickItems({ jobs: [] })).toEqual([]);
+	});
 });

--- a/editors/vscode/src/commandResultHandler.ts
+++ b/editors/vscode/src/commandResultHandler.ts
@@ -1,30 +1,30 @@
 export interface JobHistory {
-  textDocument: { uri: string };
-  id: string;
-  owner: string;
-  summary: string;
+	textDocument: { uri: string };
+	id: string;
+	owner: string;
+	summary: string;
 }
 
 export interface ListJobHistoryResult {
-  jobs: JobHistory[];
+	jobs: JobHistory[];
 }
 
 export interface JobHistoryQuickPickItem {
-  label: string;
-  description: string;
-  uri: string;
+	label: string;
+	description: string;
+	uri: string;
 }
 
 export function isExternalUrl(url: string): boolean {
-  return url.startsWith("http://") || url.startsWith("https://");
+	return url.startsWith("http://") || url.startsWith("https://");
 }
 
 export function jobHistoryQuickPickItems(
-  result: ListJobHistoryResult,
+	result: ListJobHistoryResult,
 ): JobHistoryQuickPickItem[] {
-  return result.jobs.map((job) => ({
-    label: job.summary,
-    description: job.owner,
-    uri: job.textDocument.uri,
-  }));
+	return result.jobs.map((job) => ({
+		label: job.summary,
+		description: job.owner,
+		uri: job.textDocument.uri,
+	}));
 }

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -6,51 +6,51 @@ import * as https from "node:https";
 import { promisify } from "node:util";
 import * as vscode from "vscode";
 import {
-  LanguageClient,
-  LanguageClientOptions,
-  ServerOptions,
-  TransportKind,
+	LanguageClient,
+	LanguageClientOptions,
+	ServerOptions,
+	TransportKind,
 } from "vscode-languageclient/node";
 import { InstallerDeps, resolveBqlsCommand } from "./bqlsInstaller";
 import {
-  PublishVirtualTextDocumentParams,
-  VirtualTextDocumentResult,
+	PublishVirtualTextDocumentParams,
+	VirtualTextDocumentResult,
 } from "./virtualDocument";
 import {
-  isExternalUrl,
-  jobHistoryQuickPickItems,
-  ListJobHistoryResult,
+	isExternalUrl,
+	jobHistoryQuickPickItems,
+	ListJobHistoryResult,
 } from "./commandResultHandler";
 import {
-  buildDetailsHtml,
-  buildPreviewHtml,
-  buildVirtualDocumentHtml,
-  renderPage,
-  virtualDocumentTitle,
+	buildDetailsHtml,
+	buildPreviewHtml,
+	buildVirtualDocumentHtml,
+	renderPage,
+	virtualDocumentTitle,
 } from "./webviewContent";
 import {
-  BqlsTreeNode,
-  COMMAND_LIST_DATASETS,
-  COMMAND_LIST_PROJECTS,
-  COMMAND_LIST_TABLES,
-  COMMAND_SEARCH_TABLES,
-  ListDatasetsResult,
-  ListProjectsResult,
-  ListTablesResult,
-  SearchTablesResult,
-  addProjectId,
-  addableProjectQuickPickItems,
-  datasetNodes,
-  describeTreeItem,
-  listDatasetsArguments,
-  listProjectsArguments,
-  listTablesArguments,
-  removeProjectId,
-  rootNodes,
-  searchResultQuickPickItems,
-  searchTablesArguments,
-  tableNodes,
-  tableVirtualDocumentUri,
+	BqlsTreeNode,
+	COMMAND_LIST_DATASETS,
+	COMMAND_LIST_PROJECTS,
+	COMMAND_LIST_TABLES,
+	COMMAND_SEARCH_TABLES,
+	ListDatasetsResult,
+	ListProjectsResult,
+	ListTablesResult,
+	SearchTablesResult,
+	addProjectId,
+	addableProjectQuickPickItems,
+	datasetNodes,
+	describeTreeItem,
+	listDatasetsArguments,
+	listProjectsArguments,
+	listTablesArguments,
+	removeProjectId,
+	rootNodes,
+	searchResultQuickPickItems,
+	searchTablesArguments,
+	tableNodes,
+	tableVirtualDocumentUri,
 } from "./treeView";
 
 const VIRTUAL_SCHEME = "bqls";
@@ -79,128 +79,128 @@ const webviewPanels = new Map<string, vscode.WebviewPanel>();
 // bqls/publishVirtualTextDocument (see the onNotification handler in
 // activate). Older servers just return the full result synchronously.
 async function openVirtualDocument(uriString: string): Promise<void> {
-  if (!client) {
-    return;
-  }
+	if (!client) {
+		return;
+	}
 
-  const existing = webviewPanels.get(uriString);
-  if (existing) {
-    existing.reveal();
-    return;
-  }
+	const existing = webviewPanels.get(uriString);
+	if (existing) {
+		existing.reveal();
+		return;
+	}
 
-  const panel = vscode.window.createWebviewPanel(
-    "bqlsVirtualDocument",
-    virtualDocumentTitle(uriString),
-    vscode.ViewColumn.Active,
-    // retainContextWhenHidden: without this, VSCode tears down the webview's
-    // DOM state whenever the panel is backgrounded (e.g. the user switches
-    // tabs). Since the async fetch's postMessage updates only touch the live
-    // DOM (not panel.webview.html), a backgrounded-then-reopened panel would
-    // otherwise reload from the original "Loading..." html and get stuck
-    // there even though the data already arrived.
-    { enableScripts: true, retainContextWhenHidden: true },
-  );
-  panel.webview.html = renderPage({
-    detailsHtml: "Loading...",
-    previewHtml: "Loading...",
-  });
-  webviewPanels.set(uriString, panel);
-  panel.onDidDispose(() => {
-    webviewPanels.delete(uriString);
-  });
+	const panel = vscode.window.createWebviewPanel(
+		"bqlsVirtualDocument",
+		virtualDocumentTitle(uriString),
+		vscode.ViewColumn.Active,
+		// retainContextWhenHidden: without this, VSCode tears down the webview's
+		// DOM state whenever the panel is backgrounded (e.g. the user switches
+		// tabs). Since the async fetch's postMessage updates only touch the live
+		// DOM (not panel.webview.html), a backgrounded-then-reopened panel would
+		// otherwise reload from the original "Loading..." html and get stuck
+		// there even though the data already arrived.
+		{ enableScripts: true, retainContextWhenHidden: true },
+	);
+	panel.webview.html = renderPage({
+		detailsHtml: "Loading...",
+		previewHtml: "Loading...",
+	});
+	webviewPanels.set(uriString, panel);
+	panel.onDidDispose(() => {
+		webviewPanels.delete(uriString);
+	});
 
-  const result = await client.sendRequest<VirtualTextDocumentResult>(
-    "bqls/virtualTextDocument",
-    { textDocument: { uri: uriString } },
-  );
+	const result = await client.sendRequest<VirtualTextDocumentResult>(
+		"bqls/virtualTextDocument",
+		{ textDocument: { uri: uriString } },
+	);
 
-  if (!result.pending) {
-    const { detailsHtml, previewHtml } = buildVirtualDocumentHtml(
-      result.contents,
-      result.result,
-      result.schema,
-    );
-    panel.webview.html = renderPage({ detailsHtml, previewHtml });
-  }
-  // If result.pending is true, wait for the bqls/publishVirtualTextDocument
-  // notification to fill in the panel via postMessage.
+	if (!result.pending) {
+		const { detailsHtml, previewHtml } = buildVirtualDocumentHtml(
+			result.contents,
+			result.result,
+			result.schema,
+		);
+		panel.webview.html = renderPage({ detailsHtml, previewHtml });
+	}
+	// If result.pending is true, wait for the bqls/publishVirtualTextDocument
+	// notification to fill in the panel via postMessage.
 }
 
 // Executing a Code Action (Command) that bqls returns doesn't show anything
 // in the editor by itself, so handle each command's result on the VSCode
 // side to open or notify.
 async function handleCommandResult(
-  command: string,
-  result: unknown,
+	command: string,
+	result: unknown,
 ): Promise<void> {
-  switch (command) {
-    case COMMAND_EXECUTE_QUERY: {
-      const uri = (result as { textDocument?: { uri?: string } })
-        ?.textDocument?.uri;
-      if (uri) {
-        await openVirtualDocument(uri);
-      }
-      break;
-    }
-    case COMMAND_LIST_JOB_HISTORIES: {
-      const items = jobHistoryQuickPickItems(result as ListJobHistoryResult);
-      const picked = await vscode.window.showQuickPick(items, {
-        placeHolder: "Select a job to view",
-      });
-      if (picked) {
-        await openVirtualDocument(picked.uri);
-      }
-      break;
-    }
-    case COMMAND_SAVE_RESULT: {
-      const url = (result as { url?: string })?.url;
-      if (url) {
-        if (isExternalUrl(url)) {
-          await vscode.env.openExternal(vscode.Uri.parse(url));
-        } else {
-          void vscode.window.showInformationMessage(`Saved result to ${url}`);
-        }
-      }
-      break;
-    }
-  }
+	switch (command) {
+		case COMMAND_EXECUTE_QUERY: {
+			const uri = (result as { textDocument?: { uri?: string } })?.textDocument
+				?.uri;
+			if (uri) {
+				await openVirtualDocument(uri);
+			}
+			break;
+		}
+		case COMMAND_LIST_JOB_HISTORIES: {
+			const items = jobHistoryQuickPickItems(result as ListJobHistoryResult);
+			const picked = await vscode.window.showQuickPick(items, {
+				placeHolder: "Select a job to view",
+			});
+			if (picked) {
+				await openVirtualDocument(picked.uri);
+			}
+			break;
+		}
+		case COMMAND_SAVE_RESULT: {
+			const url = (result as { url?: string })?.url;
+			if (url) {
+				if (isExternalUrl(url)) {
+					await vscode.env.openExternal(vscode.Uri.parse(url));
+				} else {
+					void vscode.window.showInformationMessage(`Saved result to ${url}`);
+				}
+			}
+			break;
+		}
+	}
 }
 
 // When a Go to Definition target is a bqls:// document, VSCode's standard
 // jump would open it as a plain text editor and bypass the webview, so
 // intercept it here instead.
 async function handleDefinitionResult(
-  result: vscode.Definition | vscode.DefinitionLink[] | null | undefined,
+	result: vscode.Definition | vscode.DefinitionLink[] | null | undefined,
 ): Promise<vscode.Definition | vscode.DefinitionLink[] | null | undefined> {
-  if (!result) {
-    return result;
-  }
+	if (!result) {
+		return result;
+	}
 
-  const locations = Array.isArray(result) ? result : [result];
-  const otherLocations: (vscode.Location | vscode.DefinitionLink)[] = [];
-  const virtualUris: string[] = [];
+	const locations = Array.isArray(result) ? result : [result];
+	const otherLocations: (vscode.Location | vscode.DefinitionLink)[] = [];
+	const virtualUris: string[] = [];
 
-  for (const loc of locations) {
-    const uri = "targetUri" in loc ? loc.targetUri : loc.uri;
-    if (uri.scheme === VIRTUAL_SCHEME) {
-      virtualUris.push(uri.toString());
-    } else {
-      otherLocations.push(loc);
-    }
-  }
+	for (const loc of locations) {
+		const uri = "targetUri" in loc ? loc.targetUri : loc.uri;
+		if (uri.scheme === VIRTUAL_SCHEME) {
+			virtualUris.push(uri.toString());
+		} else {
+			otherLocations.push(loc);
+		}
+	}
 
-  for (const uriString of virtualUris) {
-    await openVirtualDocument(uriString);
-  }
+	for (const uriString of virtualUris) {
+		await openVirtualDocument(uriString);
+	}
 
-  if (virtualUris.length === 0) {
-    return result;
-  }
-  if (otherLocations.length === 0) {
-    return null;
-  }
-  return otherLocations as vscode.Definition | vscode.DefinitionLink[];
+	if (virtualUris.length === 0) {
+		return result;
+	}
+	if (otherLocations.length === 0) {
+		return null;
+	}
+	return otherLocations as vscode.Definition | vscode.DefinitionLink[];
 }
 
 const execFileAsync = promisify(execFile);
@@ -208,108 +208,110 @@ const execFileAsync = promisify(execFile);
 // GitHub release asset downloads respond with a redirect to
 // objects.githubusercontent.com; https.get does not follow redirects itself.
 function httpGetFollowingRedirects(
-  url: string,
-  redirectsLeft = 5,
+	url: string,
+	redirectsLeft = 5,
 ): Promise<NodeJS.ReadableStream> {
-  return new Promise((resolve, reject) => {
-    https
-      .get(url, (res) => {
-        const status = res.statusCode ?? 0;
-        if (status >= 300 && status < 400 && res.headers.location) {
-          res.resume();
-          if (redirectsLeft === 0) {
-            reject(new Error(`too many redirects for ${url}`));
-            return;
-          }
-          resolve(httpGetFollowingRedirects(res.headers.location, redirectsLeft - 1));
-          return;
-        }
-        if (status !== 200) {
-          res.resume();
-          reject(new Error(`request to ${url} failed with status ${status}`));
-          return;
-        }
-        resolve(res);
-      })
-      .on("error", reject);
-  });
+	return new Promise((resolve, reject) => {
+		https
+			.get(url, (res) => {
+				const status = res.statusCode ?? 0;
+				if (status >= 300 && status < 400 && res.headers.location) {
+					res.resume();
+					if (redirectsLeft === 0) {
+						reject(new Error(`too many redirects for ${url}`));
+						return;
+					}
+					resolve(
+						httpGetFollowingRedirects(res.headers.location, redirectsLeft - 1),
+					);
+					return;
+				}
+				if (status !== 200) {
+					res.resume();
+					reject(new Error(`request to ${url} failed with status ${status}`));
+					return;
+				}
+				resolve(res);
+			})
+			.on("error", reject);
+	});
 }
 
 async function downloadText(url: string): Promise<string> {
-  const stream = await httpGetFollowingRedirects(url);
-  const chunks: Buffer[] = [];
-  for await (const chunk of stream) {
-    chunks.push(chunk as Buffer);
-  }
-  return Buffer.concat(chunks).toString("utf8");
+	const stream = await httpGetFollowingRedirects(url);
+	const chunks: Buffer[] = [];
+	for await (const chunk of stream) {
+		chunks.push(chunk as Buffer);
+	}
+	return Buffer.concat(chunks).toString("utf8");
 }
 
 async function downloadFile(url: string, destPath: string): Promise<void> {
-  const stream = await httpGetFollowingRedirects(url);
-  await new Promise<void>((resolve, reject) => {
-    const fileStream = createWriteStream(destPath);
-    stream.on("error", reject);
-    fileStream.on("error", reject);
-    fileStream.on("finish", resolve);
-    stream.pipe(fileStream);
-  });
+	const stream = await httpGetFollowingRedirects(url);
+	await new Promise<void>((resolve, reject) => {
+		const fileStream = createWriteStream(destPath);
+		stream.on("error", reject);
+		fileStream.on("error", reject);
+		fileStream.on("finish", resolve);
+		stream.pipe(fileStream);
+	});
 }
 
 function createNodeInstallerDeps(): InstallerDeps {
-  return {
-    fileExists: async (path) => {
-      try {
-        await fs.access(path);
-        return true;
-      } catch {
-        return false;
-      }
-    },
-    mkdir: async (path) => {
-      await fs.mkdir(path, { recursive: true });
-    },
-    downloadText,
-    downloadFile: async (url, destPath) => {
-      await vscode.window.withProgress(
-        {
-          location: vscode.ProgressLocation.Notification,
-          title: "Downloading bqls...",
-        },
-        () => downloadFile(url, destPath),
-      );
-    },
-    extractTarGz: async (archivePath, destDir) => {
-      await execFileAsync("tar", ["-xzf", archivePath, "-C", destDir]);
-    },
-    chmodExecutable: async (path) => {
-      await fs.chmod(path, 0o755);
-    },
-    sha256File: async (path) => {
-      const data = await fs.readFile(path);
-      return crypto.createHash("sha256").update(data).digest("hex");
-    },
-    checkOnPath: async (command) => {
-      try {
-        await execFileAsync(command, ["--version"]);
-        return true;
-      } catch {
-        return false;
-      }
-    },
-  };
+	return {
+		fileExists: async (path) => {
+			try {
+				await fs.access(path);
+				return true;
+			} catch {
+				return false;
+			}
+		},
+		mkdir: async (path) => {
+			await fs.mkdir(path, { recursive: true });
+		},
+		downloadText,
+		downloadFile: async (url, destPath) => {
+			await vscode.window.withProgress(
+				{
+					location: vscode.ProgressLocation.Notification,
+					title: "Downloading bqls...",
+				},
+				() => downloadFile(url, destPath),
+			);
+		},
+		extractTarGz: async (archivePath, destDir) => {
+			await execFileAsync("tar", ["-xzf", archivePath, "-C", destDir]);
+		},
+		chmodExecutable: async (path) => {
+			await fs.chmod(path, 0o755);
+		},
+		sha256File: async (path) => {
+			const data = await fs.readFile(path);
+			return crypto.createHash("sha256").update(data).digest("hex");
+		},
+		checkOnPath: async (command) => {
+			try {
+				await execFileAsync(command, ["--version"]);
+				return true;
+			} catch {
+				return false;
+			}
+		},
+	};
 }
 
 function buildSettings(): {
-  project_id: string;
-  location: string;
-  supports_async_virtual_text_document: boolean;
+	project_id: string;
+	location: string;
+	supports_async_virtual_text_document: boolean;
 } {
-  const config = vscode.workspace.getConfiguration("bqls");
-  return {
-    project_id: config.get<string>("projectId") ?? "",
-    location: config.get<string>("location") ?? "",
-    supports_async_virtual_text_document: true,
-  };
+	const config = vscode.workspace.getConfiguration("bqls");
+	return {
+		project_id: config.get<string>("projectId") ?? "",
+		location: config.get<string>("location") ?? "",
+		supports_async_virtual_text_document: true,
+	};
 }
 
 // The list of projects shown in the Datasets explorer (bqls.projectIds) is
@@ -319,7 +321,9 @@ function buildSettings(): {
 // back from one to the other would make "remove" ambiguous (removing the
 // last explorer project could make it reappear via bqls.projectId).
 function getExplorerProjectIds(): string[] {
-  return vscode.workspace.getConfiguration("bqls").get<string[]>("projectIds") ?? [];
+	return (
+		vscode.workspace.getConfiguration("bqls").get<string[]>("projectIds") ?? []
+	);
 }
 
 // Mirrors bqls.nvim's sidebar (lua/bqls/sidebar.lua): a lazily-loaded
@@ -330,300 +334,305 @@ function getExplorerProjectIds(): string[] {
 // the command to be advertised in the server's initialize capabilities
 // (which bqls.searchTables currently is not).
 class BqlsTreeDataProvider implements vscode.TreeDataProvider<BqlsTreeNode> {
-  private readonly _onDidChangeTreeData = new vscode.EventEmitter<
-    BqlsTreeNode | undefined
-  >();
-  readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
+	private readonly _onDidChangeTreeData = new vscode.EventEmitter<
+		BqlsTreeNode | undefined
+	>();
+	readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
 
-  refresh(): void {
-    this._onDidChangeTreeData.fire(undefined);
-  }
+	refresh(): void {
+		this._onDidChangeTreeData.fire(undefined);
+	}
 
-  getTreeItem(node: BqlsTreeNode): vscode.TreeItem {
-    const descriptor = describeTreeItem(node);
-    const item = new vscode.TreeItem(
-      descriptor.label,
-      descriptor.collapsible === "collapsed"
-        ? vscode.TreeItemCollapsibleState.Collapsed
-        : vscode.TreeItemCollapsibleState.None,
-    );
-    item.iconPath = new vscode.ThemeIcon(descriptor.icon);
-    if (descriptor.contextValue) {
-      item.contextValue = descriptor.contextValue;
-    }
-    if (node.kind === "table") {
-      item.command = {
-        command: COMMAND_OPEN_TABLE_FROM_TREE,
-        title: "Open",
-        arguments: [
-          tableVirtualDocumentUri(node.projectId, node.datasetId, node.tableId),
-        ],
-      };
-    } else if (node.kind === "message") {
-      item.command = {
-        command: COMMAND_ADD_PROJECT_TO_EXPLORER,
-        title: "Add Project",
-      };
-    }
-    return item;
-  }
+	getTreeItem(node: BqlsTreeNode): vscode.TreeItem {
+		const descriptor = describeTreeItem(node);
+		const item = new vscode.TreeItem(
+			descriptor.label,
+			descriptor.collapsible === "collapsed"
+				? vscode.TreeItemCollapsibleState.Collapsed
+				: vscode.TreeItemCollapsibleState.None,
+		);
+		item.iconPath = new vscode.ThemeIcon(descriptor.icon);
+		if (descriptor.contextValue) {
+			item.contextValue = descriptor.contextValue;
+		}
+		if (node.kind === "table") {
+			item.command = {
+				command: COMMAND_OPEN_TABLE_FROM_TREE,
+				title: "Open",
+				arguments: [
+					tableVirtualDocumentUri(node.projectId, node.datasetId, node.tableId),
+				],
+			};
+		} else if (node.kind === "message") {
+			item.command = {
+				command: COMMAND_ADD_PROJECT_TO_EXPLORER,
+				title: "Add Project",
+			};
+		}
+		return item;
+	}
 
-  async getChildren(node?: BqlsTreeNode): Promise<BqlsTreeNode[]> {
-    if (!client) {
-      return [];
-    }
-    if (!node) {
-      return rootNodes(getExplorerProjectIds());
-    }
-    try {
-      switch (node.kind) {
-        case "project": {
-          const result = await client.sendRequest<ListDatasetsResult>(
-            "workspace/executeCommand",
-            {
-              command: COMMAND_LIST_DATASETS,
-              arguments: listDatasetsArguments(node.projectId),
-            },
-          );
-          return datasetNodes(node.projectId, result);
-        }
-        case "dataset": {
-          const result = await client.sendRequest<ListTablesResult>(
-            "workspace/executeCommand",
-            {
-              command: COMMAND_LIST_TABLES,
-              arguments: listTablesArguments(node.projectId, node.datasetId),
-            },
-          );
-          return tableNodes(node.projectId, node.datasetId, result);
-        }
-        default:
-          return [];
-      }
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      void vscode.window.showErrorMessage(`bqls: ${message}`);
-      return [];
-    }
-  }
+	async getChildren(node?: BqlsTreeNode): Promise<BqlsTreeNode[]> {
+		if (!client) {
+			return [];
+		}
+		if (!node) {
+			return rootNodes(getExplorerProjectIds());
+		}
+		try {
+			switch (node.kind) {
+				case "project": {
+					const result = await client.sendRequest<ListDatasetsResult>(
+						"workspace/executeCommand",
+						{
+							command: COMMAND_LIST_DATASETS,
+							arguments: listDatasetsArguments(node.projectId),
+						},
+					);
+					return datasetNodes(node.projectId, result);
+				}
+				case "dataset": {
+					const result = await client.sendRequest<ListTablesResult>(
+						"workspace/executeCommand",
+						{
+							command: COMMAND_LIST_TABLES,
+							arguments: listTablesArguments(node.projectId, node.datasetId),
+						},
+					);
+					return tableNodes(node.projectId, node.datasetId, result);
+				}
+				default:
+					return [];
+			}
+		} catch (err) {
+			const message = err instanceof Error ? err.message : String(err);
+			void vscode.window.showErrorMessage(`bqls: ${message}`);
+			return [];
+		}
+	}
 }
 
 async function setExplorerProjectIds(projectIds: string[]): Promise<void> {
-  await vscode.workspace
-    .getConfiguration("bqls")
-    .update("projectIds", projectIds, vscode.ConfigurationTarget.Global);
+	await vscode.workspace
+		.getConfiguration("bqls")
+		.update("projectIds", projectIds, vscode.ConfigurationTarget.Global);
 }
 
 async function addProjectToExplorer(): Promise<void> {
-  if (!client) {
-    return;
-  }
+	if (!client) {
+		return;
+	}
 
-  let projectId: string | undefined;
-  try {
-    const result = await client.sendRequest<ListProjectsResult>(
-      "workspace/executeCommand",
-      { command: COMMAND_LIST_PROJECTS, arguments: listProjectsArguments() },
-    );
-    const items = addableProjectQuickPickItems(result, getExplorerProjectIds());
-    if (items.length === 0) {
-      void vscode.window.showInformationMessage(
-        "bqls: no more accessible BigQuery projects to add",
-      );
-      return;
-    }
-    const picked = await vscode.window.showQuickPick(items, {
-      placeHolder: "Select a BigQuery project to add",
-    });
-    projectId = picked?.projectId;
-  } catch (err) {
-    // Listing projects requires resourcemanager.projects.list; fall back to
-    // manual entry so the explorer still works without that permission.
-    const message = err instanceof Error ? err.message : String(err);
-    void vscode.window.showWarningMessage(
-      `bqls: failed to list BigQuery projects (${message}). Enter a project id manually.`,
-    );
-    projectId = await vscode.window.showInputBox({ prompt: "BigQuery project ID" });
-  }
+	let projectId: string | undefined;
+	try {
+		const result = await client.sendRequest<ListProjectsResult>(
+			"workspace/executeCommand",
+			{ command: COMMAND_LIST_PROJECTS, arguments: listProjectsArguments() },
+		);
+		const items = addableProjectQuickPickItems(result, getExplorerProjectIds());
+		if (items.length === 0) {
+			void vscode.window.showInformationMessage(
+				"bqls: no more accessible BigQuery projects to add",
+			);
+			return;
+		}
+		const picked = await vscode.window.showQuickPick(items, {
+			placeHolder: "Select a BigQuery project to add",
+		});
+		projectId = picked?.projectId;
+	} catch (err) {
+		// Listing projects requires resourcemanager.projects.list; fall back to
+		// manual entry so the explorer still works without that permission.
+		const message = err instanceof Error ? err.message : String(err);
+		void vscode.window.showWarningMessage(
+			`bqls: failed to list BigQuery projects (${message}). Enter a project id manually.`,
+		);
+		projectId = await vscode.window.showInputBox({
+			prompt: "BigQuery project ID",
+		});
+	}
 
-  if (!projectId) {
-    return;
-  }
-  await setExplorerProjectIds(addProjectId(getExplorerProjectIds(), projectId));
+	if (!projectId) {
+		return;
+	}
+	await setExplorerProjectIds(addProjectId(getExplorerProjectIds(), projectId));
 }
 
 async function removeProjectFromExplorer(node?: BqlsTreeNode): Promise<void> {
-  if (!node || node.kind !== "project") {
-    return;
-  }
-  await setExplorerProjectIds(removeProjectId(getExplorerProjectIds(), node.projectId));
+	if (!node || node.kind !== "project") {
+		return;
+	}
+	await setExplorerProjectIds(
+		removeProjectId(getExplorerProjectIds(), node.projectId),
+	);
 }
 
 async function searchTablesInExplorer(): Promise<void> {
-  if (!client) {
-    return;
-  }
-  const projectIds = getExplorerProjectIds();
-  if (projectIds.length === 0) {
-    void vscode.window.showWarningMessage(
-      'Add a BigQuery project to the Datasets explorer (click "+") before searching tables.',
-    );
-    return;
-  }
+	if (!client) {
+		return;
+	}
+	const projectIds = getExplorerProjectIds();
+	if (projectIds.length === 0) {
+		void vscode.window.showWarningMessage(
+			'Add a BigQuery project to the Datasets explorer (click "+") before searching tables.',
+		);
+		return;
+	}
 
-  const query = await vscode.window.showInputBox({ prompt: "Search tables" });
-  if (!query) {
-    return;
-  }
+	const query = await vscode.window.showInputBox({ prompt: "Search tables" });
+	if (!query) {
+		return;
+	}
 
-  try {
-    const result = await client.sendRequest<SearchTablesResult>(
-      "workspace/executeCommand",
-      {
-        command: COMMAND_SEARCH_TABLES,
-        arguments: searchTablesArguments(query, projectIds),
-      },
-    );
-    const items = searchResultQuickPickItems(result);
-    if (items.length === 0) {
-      void vscode.window.showInformationMessage("bqls: no tables found");
-      return;
-    }
+	try {
+		const result = await client.sendRequest<SearchTablesResult>(
+			"workspace/executeCommand",
+			{
+				command: COMMAND_SEARCH_TABLES,
+				arguments: searchTablesArguments(query, projectIds),
+			},
+		);
+		const items = searchResultQuickPickItems(result);
+		if (items.length === 0) {
+			void vscode.window.showInformationMessage("bqls: no tables found");
+			return;
+		}
 
-    const picked = await vscode.window.showQuickPick(items, {
-      placeHolder: "Search Tables",
-    });
-    if (picked) {
-      await openVirtualDocument(picked.uri);
-    }
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    void vscode.window.showErrorMessage(`bqls: ${message}`);
-  }
+		const picked = await vscode.window.showQuickPick(items, {
+			placeHolder: "Search Tables",
+		});
+		if (picked) {
+			await openVirtualDocument(picked.uri);
+		}
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		void vscode.window.showErrorMessage(`bqls: ${message}`);
+	}
 }
 
 export async function activate(
-  context: vscode.ExtensionContext,
+	context: vscode.ExtensionContext,
 ): Promise<void> {
-  const config = vscode.workspace.getConfiguration("bqls");
-  const configuredPath = config.get<string>("path") ?? "bqls";
-  const { command, error } = await resolveBqlsCommand(
-    configuredPath,
-    context.globalStorageUri.fsPath,
-    process.platform,
-    process.arch,
-    createNodeInstallerDeps(),
-  );
-  if (error) {
-    void vscode.window.showWarningMessage(error);
-  }
+	const config = vscode.workspace.getConfiguration("bqls");
+	const configuredPath = config.get<string>("path") ?? "bqls";
+	const { command, error } = await resolveBqlsCommand(
+		configuredPath,
+		context.globalStorageUri.fsPath,
+		process.platform,
+		process.arch,
+		createNodeInstallerDeps(),
+	);
+	if (error) {
+		void vscode.window.showWarningMessage(error);
+	}
 
-  const serverOptions: ServerOptions = {
-    command,
-    transport: TransportKind.stdio,
-  };
+	const serverOptions: ServerOptions = {
+		command,
+		transport: TransportKind.stdio,
+	};
 
-  const clientOptions: LanguageClientOptions = {
-    documentSelector: [{ scheme: "file", language: "sql" }],
-    initializationOptions: buildSettings(),
-    middleware: {
-      executeCommand: async (command, args, next) => {
-        const result = await next(command, args);
-        await handleCommandResult(command, result);
-        return result;
-      },
-      provideDefinition: async (document, position, token, next) => {
-        const result = await next(document, position, token);
-        return handleDefinitionResult(result);
-      },
-    },
-  };
+	const clientOptions: LanguageClientOptions = {
+		documentSelector: [{ scheme: "file", language: "sql" }],
+		initializationOptions: buildSettings(),
+		middleware: {
+			executeCommand: async (command, args, next) => {
+				const result = await next(command, args);
+				await handleCommandResult(command, result);
+				return result;
+			},
+			provideDefinition: async (document, position, token, next) => {
+				const result = await next(document, position, token);
+				return handleDefinitionResult(result);
+			},
+		},
+	};
 
-  client = new LanguageClient("bqls", "bqls", serverOptions, clientOptions);
+	client = new LanguageClient("bqls", "bqls", serverOptions, clientOptions);
 
-  const treeDataProvider = new BqlsTreeDataProvider();
-  context.subscriptions.push(
-    vscode.window.createTreeView("bqlsDatasetExplorer", { treeDataProvider }),
-  );
-  context.subscriptions.push(
-    vscode.commands.registerCommand(COMMAND_REFRESH_DATASET_EXPLORER, () =>
-      treeDataProvider.refresh(),
-    ),
-    vscode.commands.registerCommand(COMMAND_OPEN_TABLE_FROM_TREE, (uri: string) =>
-      openVirtualDocument(uri),
-    ),
-    vscode.commands.registerCommand(
-      COMMAND_SEARCH_TABLES_IN_EXPLORER,
-      searchTablesInExplorer,
-    ),
-    vscode.commands.registerCommand(
-      COMMAND_ADD_PROJECT_TO_EXPLORER,
-      addProjectToExplorer,
-    ),
-    vscode.commands.registerCommand(
-      COMMAND_REMOVE_PROJECT_FROM_EXPLORER,
-      removeProjectFromExplorer,
-    ),
-  );
+	const treeDataProvider = new BqlsTreeDataProvider();
+	context.subscriptions.push(
+		vscode.window.createTreeView("bqlsDatasetExplorer", { treeDataProvider }),
+	);
+	context.subscriptions.push(
+		vscode.commands.registerCommand(COMMAND_REFRESH_DATASET_EXPLORER, () =>
+			treeDataProvider.refresh(),
+		),
+		vscode.commands.registerCommand(
+			COMMAND_OPEN_TABLE_FROM_TREE,
+			(uri: string) => openVirtualDocument(uri),
+		),
+		vscode.commands.registerCommand(
+			COMMAND_SEARCH_TABLES_IN_EXPLORER,
+			searchTablesInExplorer,
+		),
+		vscode.commands.registerCommand(
+			COMMAND_ADD_PROJECT_TO_EXPLORER,
+			addProjectToExplorer,
+		),
+		vscode.commands.registerCommand(
+			COMMAND_REMOVE_PROJECT_FROM_EXPLORER,
+			removeProjectFromExplorer,
+		),
+	);
 
-  context.subscriptions.push(
-    client.onNotification(
-      "bqls/publishVirtualTextDocument",
-      (params: PublishVirtualTextDocumentParams) => {
-        const panel = webviewPanels.get(params.textDocument.uri);
-        if (!panel) {
-          return; // panel was closed before the fetch completed
-        }
-        if (params.error) {
-          void panel.webview.postMessage({
-            type: "error",
-            message: params.error,
-          });
-          return;
-        }
-        if (params.kind === "details") {
-          void panel.webview.postMessage({
-            type: "details",
-            detailsHtml: buildDetailsHtml(params.contents, params.schema),
-          });
-          return;
-        }
-        if (params.kind === "preview") {
-          void panel.webview.postMessage({
-            type: "preview",
-            previewHtml: buildPreviewHtml(params.result),
-          });
-        }
-      },
-    ),
-  );
+	context.subscriptions.push(
+		client.onNotification(
+			"bqls/publishVirtualTextDocument",
+			(params: PublishVirtualTextDocumentParams) => {
+				const panel = webviewPanels.get(params.textDocument.uri);
+				if (!panel) {
+					return; // panel was closed before the fetch completed
+				}
+				if (params.error) {
+					void panel.webview.postMessage({
+						type: "error",
+						message: params.error,
+					});
+					return;
+				}
+				if (params.kind === "details") {
+					void panel.webview.postMessage({
+						type: "details",
+						detailsHtml: buildDetailsHtml(params.contents, params.schema),
+					});
+					return;
+				}
+				if (params.kind === "preview") {
+					void panel.webview.postMessage({
+						type: "preview",
+						previewHtml: buildPreviewHtml(params.result),
+					});
+				}
+			},
+		),
+	);
 
-  context.subscriptions.push(
-    vscode.workspace.onDidChangeConfiguration((event) => {
-      if (!client) {
-        return;
-      }
-      if (
-        event.affectsConfiguration("bqls.projectId") ||
-        event.affectsConfiguration("bqls.location")
-      ) {
-        client.sendNotification("workspace/didChangeConfiguration", {
-          settings: buildSettings(),
-        });
-      }
-      // The tree's root nodes reflect bqls.projectIds, so re-render it too.
-      if (event.affectsConfiguration("bqls.projectIds")) {
-        treeDataProvider.refresh();
-      }
-    }),
-  );
+	context.subscriptions.push(
+		vscode.workspace.onDidChangeConfiguration((event) => {
+			if (!client) {
+				return;
+			}
+			if (
+				event.affectsConfiguration("bqls.projectId") ||
+				event.affectsConfiguration("bqls.location")
+			) {
+				client.sendNotification("workspace/didChangeConfiguration", {
+					settings: buildSettings(),
+				});
+			}
+			// The tree's root nodes reflect bqls.projectIds, so re-render it too.
+			if (event.affectsConfiguration("bqls.projectIds")) {
+				treeDataProvider.refresh();
+			}
+		}),
+	);
 
-  await client.start();
+	await client.start();
 }
 
 export async function deactivate(): Promise<void> {
-  if (client) {
-    await client.stop();
-    client = undefined;
-  }
+	if (client) {
+		await client.stop();
+		client = undefined;
+	}
 }

--- a/editors/vscode/src/treeView.test.ts
+++ b/editors/vscode/src/treeView.test.ts
@@ -1,248 +1,274 @@
 import { describe, expect, it } from "vitest";
 import {
-  addProjectId,
-  addableProjectQuickPickItems,
-  datasetNodes,
-  describeTreeItem,
-  listDatasetsArguments,
-  listProjectsArguments,
-  listTablesArguments,
-  removeProjectId,
-  rootNodes,
-  searchResultQuickPickItems,
-  searchTablesArguments,
-  tableNodes,
-  tableVirtualDocumentUri,
+	addProjectId,
+	addableProjectQuickPickItems,
+	datasetNodes,
+	describeTreeItem,
+	listDatasetsArguments,
+	listProjectsArguments,
+	listTablesArguments,
+	removeProjectId,
+	rootNodes,
+	searchResultQuickPickItems,
+	searchTablesArguments,
+	tableNodes,
+	tableVirtualDocumentUri,
 } from "./treeView";
 
 describe("tableVirtualDocumentUri", () => {
-  it("matches the server's NewTableVirtualTextDocumentURI format", () => {
-    expect(tableVirtualDocumentUri("my-project", "my_dataset", "my_table")).toBe(
-      "bqls://project/my-project/dataset/my_dataset/table/my_table",
-    );
-  });
+	it("matches the server's NewTableVirtualTextDocumentURI format", () => {
+		expect(
+			tableVirtualDocumentUri("my-project", "my_dataset", "my_table"),
+		).toBe("bqls://project/my-project/dataset/my_dataset/table/my_table");
+	});
 });
 
 describe("rootNodes", () => {
-  it("returns a message node prompting the user to add a project when the list is empty", () => {
-    expect(rootNodes([])).toEqual([
-      { kind: "message", text: expect.stringContaining("project") },
-    ]);
-  });
+	it("returns a message node prompting the user to add a project when the list is empty", () => {
+		expect(rootNodes([])).toEqual([
+			{ kind: "message", text: expect.stringContaining("project") },
+		]);
+	});
 
-  it("returns one project node per project id, in order", () => {
-    expect(rootNodes(["my-project", "other-project"])).toEqual([
-      { kind: "project", projectId: "my-project" },
-      { kind: "project", projectId: "other-project" },
-    ]);
-  });
+	it("returns one project node per project id, in order", () => {
+		expect(rootNodes(["my-project", "other-project"])).toEqual([
+			{ kind: "project", projectId: "my-project" },
+			{ kind: "project", projectId: "other-project" },
+		]);
+	});
 
-  it("de-duplicates project ids", () => {
-    expect(rootNodes(["my-project", "my-project"])).toEqual([
-      { kind: "project", projectId: "my-project" },
-    ]);
-  });
+	it("de-duplicates project ids", () => {
+		expect(rootNodes(["my-project", "my-project"])).toEqual([
+			{ kind: "project", projectId: "my-project" },
+		]);
+	});
 });
 
 describe("listDatasetsArguments", () => {
-  it("wraps the projectId in a single-element array", () => {
-    expect(listDatasetsArguments("my-project")).toEqual(["my-project"]);
-  });
+	it("wraps the projectId in a single-element array", () => {
+		expect(listDatasetsArguments("my-project")).toEqual(["my-project"]);
+	});
 });
 
 describe("datasetNodes", () => {
-  it("maps dataset ids to dataset nodes under the given project", () => {
-    expect(
-      datasetNodes("my-project", { datasets: ["a", "b"] }),
-    ).toEqual([
-      { kind: "dataset", projectId: "my-project", datasetId: "a" },
-      { kind: "dataset", projectId: "my-project", datasetId: "b" },
-    ]);
-  });
+	it("maps dataset ids to dataset nodes under the given project", () => {
+		expect(datasetNodes("my-project", { datasets: ["a", "b"] })).toEqual([
+			{ kind: "dataset", projectId: "my-project", datasetId: "a" },
+			{ kind: "dataset", projectId: "my-project", datasetId: "b" },
+		]);
+	});
 
-  it("returns an empty array when there are no datasets", () => {
-    expect(datasetNodes("my-project", { datasets: [] })).toEqual([]);
-  });
+	it("returns an empty array when there are no datasets", () => {
+		expect(datasetNodes("my-project", { datasets: [] })).toEqual([]);
+	});
 });
 
 describe("listTablesArguments", () => {
-  it("returns [projectId, datasetId]", () => {
-    expect(listTablesArguments("my-project", "my_dataset")).toEqual([
-      "my-project",
-      "my_dataset",
-    ]);
-  });
+	it("returns [projectId, datasetId]", () => {
+		expect(listTablesArguments("my-project", "my_dataset")).toEqual([
+			"my-project",
+			"my_dataset",
+		]);
+	});
 });
 
 describe("tableNodes", () => {
-  it("maps table ids to table nodes under the given project/dataset", () => {
-    expect(
-      tableNodes("my-project", "my_dataset", { tables: ["t1", "t2"] }),
-    ).toEqual([
-      { kind: "table", projectId: "my-project", datasetId: "my_dataset", tableId: "t1" },
-      { kind: "table", projectId: "my-project", datasetId: "my_dataset", tableId: "t2" },
-    ]);
-  });
+	it("maps table ids to table nodes under the given project/dataset", () => {
+		expect(
+			tableNodes("my-project", "my_dataset", { tables: ["t1", "t2"] }),
+		).toEqual([
+			{
+				kind: "table",
+				projectId: "my-project",
+				datasetId: "my_dataset",
+				tableId: "t1",
+			},
+			{
+				kind: "table",
+				projectId: "my-project",
+				datasetId: "my_dataset",
+				tableId: "t2",
+			},
+		]);
+	});
 
-  it("returns an empty array when there are no tables", () => {
-    expect(tableNodes("my-project", "my_dataset", { tables: [] })).toEqual([]);
-  });
+	it("returns an empty array when there are no tables", () => {
+		expect(tableNodes("my-project", "my_dataset", { tables: [] })).toEqual([]);
+	});
 });
 
 describe("searchTablesArguments", () => {
-  it("returns [query, ...projectIds]", () => {
-    expect(searchTablesArguments("users", ["my-project", "other-project"])).toEqual([
-      "users",
-      "my-project",
-      "other-project",
-    ]);
-  });
+	it("returns [query, ...projectIds]", () => {
+		expect(
+			searchTablesArguments("users", ["my-project", "other-project"]),
+		).toEqual(["users", "my-project", "other-project"]);
+	});
 
-  it("returns just [query] when there are no project ids", () => {
-    expect(searchTablesArguments("users", [])).toEqual(["users"]);
-  });
+	it("returns just [query] when there are no project ids", () => {
+		expect(searchTablesArguments("users", [])).toEqual(["users"]);
+	});
 });
 
 describe("searchResultQuickPickItems", () => {
-  it("builds a dotted label and passes through the description", () => {
-    expect(
-      searchResultQuickPickItems({
-        tables: [
-          {
-            projectId: "my-project",
-            datasetId: "my_dataset",
-            tableId: "my_table",
-            description: "user records",
-          },
-        ],
-      }),
-    ).toEqual([
-      {
-        label: "my-project.my_dataset.my_table",
-        description: "user records",
-        uri: "bqls://project/my-project/dataset/my_dataset/table/my_table",
-      },
-    ]);
-  });
+	it("builds a dotted label and passes through the description", () => {
+		expect(
+			searchResultQuickPickItems({
+				tables: [
+					{
+						projectId: "my-project",
+						datasetId: "my_dataset",
+						tableId: "my_table",
+						description: "user records",
+					},
+				],
+			}),
+		).toEqual([
+			{
+				label: "my-project.my_dataset.my_table",
+				description: "user records",
+				uri: "bqls://project/my-project/dataset/my_dataset/table/my_table",
+			},
+		]);
+	});
 
-  it("falls back to an empty description when omitted", () => {
-    expect(
-      searchResultQuickPickItems({
-        tables: [
-          { projectId: "p", datasetId: "d", tableId: "t" },
-        ],
-      }),
-    ).toEqual([
-      { label: "p.d.t", description: "", uri: "bqls://project/p/dataset/d/table/t" },
-    ]);
-  });
+	it("falls back to an empty description when omitted", () => {
+		expect(
+			searchResultQuickPickItems({
+				tables: [{ projectId: "p", datasetId: "d", tableId: "t" }],
+			}),
+		).toEqual([
+			{
+				label: "p.d.t",
+				description: "",
+				uri: "bqls://project/p/dataset/d/table/t",
+			},
+		]);
+	});
 
-  it("returns an empty array when there are no matches", () => {
-    expect(searchResultQuickPickItems({ tables: [] })).toEqual([]);
-  });
+	it("returns an empty array when there are no matches", () => {
+		expect(searchResultQuickPickItems({ tables: [] })).toEqual([]);
+	});
 });
 
 describe("listProjectsArguments", () => {
-  it("takes no arguments", () => {
-    expect(listProjectsArguments()).toEqual([]);
-  });
+	it("takes no arguments", () => {
+		expect(listProjectsArguments()).toEqual([]);
+	});
 });
 
 describe("addableProjectQuickPickItems", () => {
-  it("maps projects to quick pick items keyed by projectId", () => {
-    expect(
-      addableProjectQuickPickItems(
-        {
-          projects: [
-            { projectId: "my-project", name: "My Project" },
-            { projectId: "other-project", name: "Other Project" },
-          ],
-        },
-        [],
-      ),
-    ).toEqual([
-      { label: "my-project", description: "My Project", projectId: "my-project" },
-      { label: "other-project", description: "Other Project", projectId: "other-project" },
-    ]);
-  });
+	it("maps projects to quick pick items keyed by projectId", () => {
+		expect(
+			addableProjectQuickPickItems(
+				{
+					projects: [
+						{ projectId: "my-project", name: "My Project" },
+						{ projectId: "other-project", name: "Other Project" },
+					],
+				},
+				[],
+			),
+		).toEqual([
+			{
+				label: "my-project",
+				description: "My Project",
+				projectId: "my-project",
+			},
+			{
+				label: "other-project",
+				description: "Other Project",
+				projectId: "other-project",
+			},
+		]);
+	});
 
-  it("excludes projects already in the explorer", () => {
-    expect(
-      addableProjectQuickPickItems(
-        {
-          projects: [
-            { projectId: "my-project", name: "My Project" },
-            { projectId: "other-project", name: "Other Project" },
-          ],
-        },
-        ["my-project"],
-      ),
-    ).toEqual([
-      { label: "other-project", description: "Other Project", projectId: "other-project" },
-    ]);
-  });
+	it("excludes projects already in the explorer", () => {
+		expect(
+			addableProjectQuickPickItems(
+				{
+					projects: [
+						{ projectId: "my-project", name: "My Project" },
+						{ projectId: "other-project", name: "Other Project" },
+					],
+				},
+				["my-project"],
+			),
+		).toEqual([
+			{
+				label: "other-project",
+				description: "Other Project",
+				projectId: "other-project",
+			},
+		]);
+	});
 });
 
 describe("addProjectId", () => {
-  it("appends a new project id", () => {
-    expect(addProjectId(["a"], "b")).toEqual(["a", "b"]);
-  });
+	it("appends a new project id", () => {
+		expect(addProjectId(["a"], "b")).toEqual(["a", "b"]);
+	});
 
-  it("leaves the list unchanged when the project id is already present", () => {
-    expect(addProjectId(["a", "b"], "b")).toEqual(["a", "b"]);
-  });
+	it("leaves the list unchanged when the project id is already present", () => {
+		expect(addProjectId(["a", "b"], "b")).toEqual(["a", "b"]);
+	});
 });
 
 describe("removeProjectId", () => {
-  it("removes the matching project id", () => {
-    expect(removeProjectId(["a", "b"], "a")).toEqual(["b"]);
-  });
+	it("removes the matching project id", () => {
+		expect(removeProjectId(["a", "b"], "a")).toEqual(["b"]);
+	});
 
-  it("leaves the list unchanged when the project id is absent", () => {
-    expect(removeProjectId(["a", "b"], "c")).toEqual(["a", "b"]);
-  });
+	it("leaves the list unchanged when the project id is absent", () => {
+		expect(removeProjectId(["a", "b"], "c")).toEqual(["a", "b"]);
+	});
 });
 
 describe("describeTreeItem", () => {
-  it("describes a message node as non-collapsible with an info icon", () => {
-    expect(describeTreeItem({ kind: "message", text: "hello" })).toEqual({
-      label: "hello",
-      collapsible: "none",
-      icon: "info",
-    });
-  });
+	it("describes a message node as non-collapsible with an info icon", () => {
+		expect(describeTreeItem({ kind: "message", text: "hello" })).toEqual({
+			label: "hello",
+			collapsible: "none",
+			icon: "info",
+		});
+	});
 
-  it("describes a project node as collapsible with a database icon and a removable contextValue", () => {
-    expect(describeTreeItem({ kind: "project", projectId: "my-project" })).toEqual({
-      label: "my-project",
-      collapsible: "collapsed",
-      icon: "database",
-      contextValue: "bqlsProject",
-    });
-  });
+	it("describes a project node as collapsible with a database icon and a removable contextValue", () => {
+		expect(
+			describeTreeItem({ kind: "project", projectId: "my-project" }),
+		).toEqual({
+			label: "my-project",
+			collapsible: "collapsed",
+			icon: "database",
+			contextValue: "bqlsProject",
+		});
+	});
 
-  it("describes a dataset node as collapsible with a database icon", () => {
-    expect(
-      describeTreeItem({ kind: "dataset", projectId: "p", datasetId: "my_dataset" }),
-    ).toEqual({
-      label: "my_dataset",
-      collapsible: "collapsed",
-      icon: "database",
-    });
-  });
+	it("describes a dataset node as collapsible with a database icon", () => {
+		expect(
+			describeTreeItem({
+				kind: "dataset",
+				projectId: "p",
+				datasetId: "my_dataset",
+			}),
+		).toEqual({
+			label: "my_dataset",
+			collapsible: "collapsed",
+			icon: "database",
+		});
+	});
 
-  it("describes a table node as non-collapsible with a table icon", () => {
-    expect(
-      describeTreeItem({
-        kind: "table",
-        projectId: "p",
-        datasetId: "d",
-        tableId: "my_table",
-      }),
-    ).toEqual({
-      label: "my_table",
-      collapsible: "none",
-      icon: "table",
-    });
-  });
+	it("describes a table node as non-collapsible with a table icon", () => {
+		expect(
+			describeTreeItem({
+				kind: "table",
+				projectId: "p",
+				datasetId: "d",
+				tableId: "my_table",
+			}),
+		).toEqual({
+			label: "my_table",
+			collapsible: "none",
+			icon: "table",
+		});
+	});
 });

--- a/editors/vscode/src/treeView.ts
+++ b/editors/vscode/src/treeView.ts
@@ -1,35 +1,35 @@
 export type BqlsTreeNode =
-  | { kind: "message"; text: string }
-  | { kind: "project"; projectId: string }
-  | { kind: "dataset"; projectId: string; datasetId: string }
-  | { kind: "table"; projectId: string; datasetId: string; tableId: string };
+	| { kind: "message"; text: string }
+	| { kind: "project"; projectId: string }
+	| { kind: "dataset"; projectId: string; datasetId: string }
+	| { kind: "table"; projectId: string; datasetId: string; tableId: string };
 
 export interface ListDatasetsResult {
-  datasets: string[];
+	datasets: string[];
 }
 
 export interface ListTablesResult {
-  tables: string[];
+	tables: string[];
 }
 
 export interface TableSearchResult {
-  projectId: string;
-  datasetId: string;
-  tableId: string;
-  description?: string;
+	projectId: string;
+	datasetId: string;
+	tableId: string;
+	description?: string;
 }
 
 export interface SearchTablesResult {
-  tables: TableSearchResult[];
+	tables: TableSearchResult[];
 }
 
 export interface ProjectInfo {
-  projectId: string;
-  name: string;
+	projectId: string;
+	name: string;
 }
 
 export interface ListProjectsResult {
-  projects: ProjectInfo[];
+	projects: ProjectInfo[];
 }
 
 export const COMMAND_LIST_DATASETS = "bqls.listDatasets";
@@ -38,11 +38,11 @@ export const COMMAND_SEARCH_TABLES = "bqls.searchTables";
 export const COMMAND_LIST_PROJECTS = "bqls.listProjects";
 
 export function tableVirtualDocumentUri(
-  projectId: string,
-  datasetId: string,
-  tableId: string,
+	projectId: string,
+	datasetId: string,
+	tableId: string,
 ): string {
-  return `bqls://project/${projectId}/dataset/${datasetId}/table/${tableId}`;
+	return `bqls://project/${projectId}/dataset/${datasetId}/table/${tableId}`;
 }
 
 // projectIds is the explicit list the user has added to the explorer
@@ -50,128 +50,142 @@ export function tableVirtualDocumentUri(
 // as the LSP server's default project. When it's empty, show a message node
 // prompting the user to add one via the "+" button instead of a project node.
 export function rootNodes(projectIds: string[]): BqlsTreeNode[] {
-  const uniqueProjectIds = Array.from(new Set(projectIds));
-  if (uniqueProjectIds.length === 0) {
-    return [
-      {
-        kind: "message",
-        text: 'Click "+" above to add a BigQuery project to the Datasets explorer.',
-      },
-    ];
-  }
-  return uniqueProjectIds.map((projectId) => ({ kind: "project", projectId }));
+	const uniqueProjectIds = Array.from(new Set(projectIds));
+	if (uniqueProjectIds.length === 0) {
+		return [
+			{
+				kind: "message",
+				text: 'Click "+" above to add a BigQuery project to the Datasets explorer.',
+			},
+		];
+	}
+	return uniqueProjectIds.map((projectId) => ({ kind: "project", projectId }));
 }
 
 export function listDatasetsArguments(projectId: string): unknown[] {
-  return [projectId];
+	return [projectId];
 }
 
 export function datasetNodes(
-  projectId: string,
-  result: ListDatasetsResult,
+	projectId: string,
+	result: ListDatasetsResult,
 ): BqlsTreeNode[] {
-  return result.datasets.map((datasetId) => ({
-    kind: "dataset",
-    projectId,
-    datasetId,
-  }));
+	return result.datasets.map((datasetId) => ({
+		kind: "dataset",
+		projectId,
+		datasetId,
+	}));
 }
 
 export function listTablesArguments(
-  projectId: string,
-  datasetId: string,
+	projectId: string,
+	datasetId: string,
 ): unknown[] {
-  return [projectId, datasetId];
+	return [projectId, datasetId];
 }
 
 export function tableNodes(
-  projectId: string,
-  datasetId: string,
-  result: ListTablesResult,
+	projectId: string,
+	datasetId: string,
+	result: ListTablesResult,
 ): BqlsTreeNode[] {
-  return result.tables.map((tableId) => ({
-    kind: "table",
-    projectId,
-    datasetId,
-    tableId,
-  }));
+	return result.tables.map((tableId) => ({
+		kind: "table",
+		projectId,
+		datasetId,
+		tableId,
+	}));
 }
 
 export function searchTablesArguments(
-  query: string,
-  projectIds: string[],
+	query: string,
+	projectIds: string[],
 ): unknown[] {
-  return [query, ...projectIds];
+	return [query, ...projectIds];
 }
 
 export interface SearchTablesQuickPickItem {
-  label: string;
-  description: string;
-  uri: string;
+	label: string;
+	description: string;
+	uri: string;
 }
 
 export function searchResultQuickPickItems(
-  result: SearchTablesResult,
+	result: SearchTablesResult,
 ): SearchTablesQuickPickItem[] {
-  return result.tables.map((t) => ({
-    label: `${t.projectId}.${t.datasetId}.${t.tableId}`,
-    description: t.description ?? "",
-    uri: tableVirtualDocumentUri(t.projectId, t.datasetId, t.tableId),
-  }));
+	return result.tables.map((t) => ({
+		label: `${t.projectId}.${t.datasetId}.${t.tableId}`,
+		description: t.description ?? "",
+		uri: tableVirtualDocumentUri(t.projectId, t.datasetId, t.tableId),
+	}));
 }
 
 export function listProjectsArguments(): unknown[] {
-  return [];
+	return [];
 }
 
 export interface ProjectQuickPickItem {
-  label: string;
-  description: string;
-  projectId: string;
+	label: string;
+	description: string;
+	projectId: string;
 }
 
 export function addableProjectQuickPickItems(
-  result: ListProjectsResult,
-  existingProjectIds: string[],
+	result: ListProjectsResult,
+	existingProjectIds: string[],
 ): ProjectQuickPickItem[] {
-  const existing = new Set(existingProjectIds);
-  return result.projects
-    .filter((p) => !existing.has(p.projectId))
-    .map((p) => ({ label: p.projectId, description: p.name, projectId: p.projectId }));
+	const existing = new Set(existingProjectIds);
+	return result.projects
+		.filter((p) => !existing.has(p.projectId))
+		.map((p) => ({
+			label: p.projectId,
+			description: p.name,
+			projectId: p.projectId,
+		}));
 }
 
-export function addProjectId(projectIds: string[], projectId: string): string[] {
-  if (projectIds.includes(projectId)) {
-    return projectIds;
-  }
-  return [...projectIds, projectId];
+export function addProjectId(
+	projectIds: string[],
+	projectId: string,
+): string[] {
+	if (projectIds.includes(projectId)) {
+		return projectIds;
+	}
+	return [...projectIds, projectId];
 }
 
-export function removeProjectId(projectIds: string[], projectId: string): string[] {
-  return projectIds.filter((id) => id !== projectId);
+export function removeProjectId(
+	projectIds: string[],
+	projectId: string,
+): string[] {
+	return projectIds.filter((id) => id !== projectId);
 }
 
 export interface TreeItemDescriptor {
-  label: string;
-  collapsible: "none" | "collapsed";
-  icon: "info" | "database" | "table";
-  contextValue?: "bqlsProject";
+	label: string;
+	collapsible: "none" | "collapsed";
+	icon: "info" | "database" | "table";
+	contextValue?: "bqlsProject";
 }
 
 export function describeTreeItem(node: BqlsTreeNode): TreeItemDescriptor {
-  switch (node.kind) {
-    case "message":
-      return { label: node.text, collapsible: "none", icon: "info" };
-    case "project":
-      return {
-        label: node.projectId,
-        collapsible: "collapsed",
-        icon: "database",
-        contextValue: "bqlsProject",
-      };
-    case "dataset":
-      return { label: node.datasetId, collapsible: "collapsed", icon: "database" };
-    case "table":
-      return { label: node.tableId, collapsible: "none", icon: "table" };
-  }
+	switch (node.kind) {
+		case "message":
+			return { label: node.text, collapsible: "none", icon: "info" };
+		case "project":
+			return {
+				label: node.projectId,
+				collapsible: "collapsed",
+				icon: "database",
+				contextValue: "bqlsProject",
+			};
+		case "dataset":
+			return {
+				label: node.datasetId,
+				collapsible: "collapsed",
+				icon: "database",
+			};
+		case "table":
+			return { label: node.tableId, collapsible: "none", icon: "table" };
+	}
 }

--- a/editors/vscode/src/virtualDocument.ts
+++ b/editors/vscode/src/virtualDocument.ts
@@ -1,31 +1,31 @@
 export type MarkedString = string | { language: string; value: string };
 
 export interface FieldSchema {
-  name: string;
-  type: string;
-  repeated?: boolean;
-  required?: boolean;
-  description?: string;
-  fields?: FieldSchema[];
+	name: string;
+	type: string;
+	repeated?: boolean;
+	required?: boolean;
+	description?: string;
+	fields?: FieldSchema[];
 }
 
 export interface QueryResult {
-  columns: string[] | null;
-  data: unknown[][] | null;
-  // schema is omitted by the server when empty; older servers may not send it at all.
-  schema?: FieldSchema[];
+	columns: string[] | null;
+	data: unknown[][] | null;
+	// schema is omitted by the server when empty; older servers may not send it at all.
+	schema?: FieldSchema[];
 }
 
 export interface VirtualTextDocumentResult {
-  contents: MarkedString[] | null;
-  result?: QueryResult;
-  // The table's schema as structured data, letting the Details tab render a
-  // collapsible tree instead of parsing the Markdown table already in
-  // contents. Only set for table (not job) virtual documents.
-  schema?: FieldSchema[];
-  // Set by servers that support supports_async_virtual_text_document: the
-  // real contents/result will follow via bqls/publishVirtualTextDocument.
-  pending?: boolean;
+	contents: MarkedString[] | null;
+	result?: QueryResult;
+	// The table's schema as structured data, letting the Details tab render a
+	// collapsible tree instead of parsing the Markdown table already in
+	// contents. Only set for table (not job) virtual documents.
+	schema?: FieldSchema[];
+	// Set by servers that support supports_async_virtual_text_document: the
+	// real contents/result will follow via bqls/publishVirtualTextDocument.
+	pending?: boolean;
 }
 
 // Pushed by the server once part of an async bqls/virtualTextDocument fetch
@@ -34,12 +34,12 @@ export interface VirtualTextDocumentResult {
 // once for "details" (usually fast) and once for "preview" (usually slower,
 // e.g. waiting for a job or scanning a large table).
 export interface PublishVirtualTextDocumentParams {
-  textDocument: { uri: string };
-  kind: "details" | "preview";
-  contents?: MarkedString[];
-  // Set alongside contents when kind is "details", for table virtual
-  // documents; see VirtualTextDocumentResult.schema.
-  schema?: FieldSchema[];
-  result?: QueryResult;
-  error?: string;
+	textDocument: { uri: string };
+	kind: "details" | "preview";
+	contents?: MarkedString[];
+	// Set alongside contents when kind is "details", for table virtual
+	// documents; see VirtualTextDocumentResult.schema.
+	schema?: FieldSchema[];
+	result?: QueryResult;
+	error?: string;
 }

--- a/editors/vscode/src/webviewContent.test.ts
+++ b/editors/vscode/src/webviewContent.test.ts
@@ -1,354 +1,354 @@
 import { describe, expect, it } from "vitest";
 import {
-  buildDetailsHtml,
-  buildPreviewHtml,
-  buildVirtualDocumentHtml,
-  escapeHtml,
-  renderCellValue,
-  renderMarkedString,
-  renderPage,
-  renderQueryResultTable,
-  renderSchemaTable,
-  virtualDocumentTitle,
+	buildDetailsHtml,
+	buildPreviewHtml,
+	buildVirtualDocumentHtml,
+	escapeHtml,
+	renderCellValue,
+	renderMarkedString,
+	renderPage,
+	renderQueryResultTable,
+	renderSchemaTable,
+	virtualDocumentTitle,
 } from "./webviewContent";
 
 describe("escapeHtml", () => {
-  it("escapes html special characters", () => {
-    expect(escapeHtml(`<b>a & "b" 'c'</b>`)).toBe(
-      "&lt;b&gt;a &amp; &quot;b&quot; &#39;c&#39;&lt;/b&gt;",
-    );
-  });
+	it("escapes html special characters", () => {
+		expect(escapeHtml(`<b>a & "b" 'c'</b>`)).toBe(
+			"&lt;b&gt;a &amp; &quot;b&quot; &#39;c&#39;&lt;/b&gt;",
+		);
+	});
 });
 
 describe("renderCellValue", () => {
-  it("renders null as a null marker", () => {
-    expect(renderCellValue(null)).toBe('<span class="bqls-null">null</span>');
-  });
+	it("renders null as a null marker", () => {
+		expect(renderCellValue(null)).toBe('<span class="bqls-null">null</span>');
+	});
 
-  it("renders a primitive value escaped", () => {
-    expect(renderCellValue("<script>")).toBe("&lt;script&gt;");
-  });
+	it("renders a primitive value escaped", () => {
+		expect(renderCellValue("<script>")).toBe("&lt;script&gt;");
+	});
 
-  it("renders a repeated (array) value as a collapsible list", () => {
-    const html = renderCellValue(["a", "b"], {
-      name: "tags",
-      type: "STRING",
-      repeated: true,
-    });
-    expect(html).toBe(
-      '<details class="bqls-nested"><summary>[2]</summary><ul><li>a</li><li>b</li></ul></details>',
-    );
-  });
+	it("renders a repeated (array) value as a collapsible list", () => {
+		const html = renderCellValue(["a", "b"], {
+			name: "tags",
+			type: "STRING",
+			repeated: true,
+		});
+		expect(html).toBe(
+			'<details class="bqls-nested"><summary>[2]</summary><ul><li>a</li><li>b</li></ul></details>',
+		);
+	});
 
-  it("renders a record value as a collapsible key-value table", () => {
-    const html = renderCellValue(["Tokyo", "100-0001"], {
-      name: "address",
-      type: "RECORD",
-      fields: [
-        { name: "city", type: "STRING" },
-        { name: "zip", type: "STRING" },
-      ],
-    });
-    expect(html).toBe(
-      '<details class="bqls-nested"><summary>{…}</summary>' +
-        '<table class="bqls-record">' +
-        "<tr><th>city</th><td>Tokyo</td></tr>" +
-        "<tr><th>zip</th><td>100-0001</td></tr>" +
-        "</table></details>",
-    );
-  });
+	it("renders a record value as a collapsible key-value table", () => {
+		const html = renderCellValue(["Tokyo", "100-0001"], {
+			name: "address",
+			type: "RECORD",
+			fields: [
+				{ name: "city", type: "STRING" },
+				{ name: "zip", type: "STRING" },
+			],
+		});
+		expect(html).toBe(
+			'<details class="bqls-nested"><summary>{…}</summary>' +
+				'<table class="bqls-record">' +
+				"<tr><th>city</th><td>Tokyo</td></tr>" +
+				"<tr><th>zip</th><td>100-0001</td></tr>" +
+				"</table></details>",
+		);
+	});
 
-  it("renders repeated record fields recursively", () => {
-    const html = renderCellValue(
-      [
-        ["Tokyo"],
-        ["Osaka"],
-      ],
-      {
-        name: "addresses",
-        type: "RECORD",
-        repeated: true,
-        fields: [{ name: "city", type: "STRING" }],
-      },
-    );
-    expect(html).toBe(
-      '<details class="bqls-nested"><summary>[2]</summary><ul>' +
-        '<li><details class="bqls-nested"><summary>{…}</summary>' +
-        '<table class="bqls-record"><tr><th>city</th><td>Tokyo</td></tr></table></details></li>' +
-        '<li><details class="bqls-nested"><summary>{…}</summary>' +
-        '<table class="bqls-record"><tr><th>city</th><td>Osaka</td></tr></table></details></li>' +
-        "</ul></details>",
-    );
-  });
+	it("renders repeated record fields recursively", () => {
+		const html = renderCellValue([["Tokyo"], ["Osaka"]], {
+			name: "addresses",
+			type: "RECORD",
+			repeated: true,
+			fields: [{ name: "city", type: "STRING" }],
+		});
+		expect(html).toBe(
+			'<details class="bqls-nested"><summary>[2]</summary><ul>' +
+				'<li><details class="bqls-nested"><summary>{…}</summary>' +
+				'<table class="bqls-record"><tr><th>city</th><td>Tokyo</td></tr></table></details></li>' +
+				'<li><details class="bqls-nested"><summary>{…}</summary>' +
+				'<table class="bqls-record"><tr><th>city</th><td>Osaka</td></tr></table></details></li>' +
+				"</ul></details>",
+		);
+	});
 });
 
 describe("renderMarkedString", () => {
-  it("renders headings", () => {
-    expect(renderMarkedString("## Job info")).toBe("<h2>Job info</h2>");
-  });
+	it("renders headings", () => {
+		expect(renderMarkedString("## Job info")).toBe("<h2>Job info</h2>");
+	});
 
-  it("renders a bullet list", () => {
-    expect(renderMarkedString("* Created: today\n* Ended: never")).toBe(
-      "<ul><li>Created: today</li><li>Ended: never</li></ul>",
-    );
-  });
+	it("renders a bullet list", () => {
+		expect(renderMarkedString("* Created: today\n* Ended: never")).toBe(
+			"<ul><li>Created: today</li><li>Ended: never</li></ul>",
+		);
+	});
 
-  it("renders a markdown link", () => {
-    expect(renderMarkedString("[Query URL](https://example.com)")).toBe(
-      '<p><a href="https://example.com">Query URL</a></p>',
-    );
-  });
+	it("renders a markdown link", () => {
+		expect(renderMarkedString("[Query URL](https://example.com)")).toBe(
+			'<p><a href="https://example.com">Query URL</a></p>',
+		);
+	});
 
-  it("renders a plain paragraph", () => {
-    expect(renderMarkedString("hello world")).toBe("<p>hello world</p>");
-  });
+	it("renders a plain paragraph", () => {
+		expect(renderMarkedString("hello world")).toBe("<p>hello world</p>");
+	});
 
-  it("renders non-markdown languages as an escaped code block", () => {
-    expect(renderMarkedString({ language: "yaml", value: "- name: id" })).toBe(
-      "<pre><code>- name: id</code></pre>",
-    );
-  });
+	it("renders non-markdown languages as an escaped code block", () => {
+		expect(renderMarkedString({ language: "yaml", value: "- name: id" })).toBe(
+			"<pre><code>- name: id</code></pre>",
+		);
+	});
 
-  it("escapes html in plain text", () => {
-    expect(renderMarkedString("<script>alert(1)</script>")).toBe(
-      "<p>&lt;script&gt;alert(1)&lt;/script&gt;</p>",
-    );
-  });
+	it("escapes html in plain text", () => {
+		expect(renderMarkedString("<script>alert(1)</script>")).toBe(
+			"<p>&lt;script&gt;alert(1)&lt;/script&gt;</p>",
+		);
+	});
 });
 
 describe("renderPage", () => {
-  it("includes tab buttons and both panels' content", () => {
-    const html = renderPage({
-      detailsHtml: "<p>details</p>",
-      previewHtml: "<table>preview</table>",
-    });
-    expect(html).toContain("<p>details</p>");
-    expect(html).toContain("<table>preview</table>");
-    expect(html).toContain('data-tab="details"');
-    expect(html).toContain('data-tab="preview"');
-  });
+	it("includes tab buttons and both panels' content", () => {
+		const html = renderPage({
+			detailsHtml: "<p>details</p>",
+			previewHtml: "<table>preview</table>",
+		});
+		expect(html).toContain("<p>details</p>");
+		expect(html).toContain("<table>preview</table>");
+		expect(html).toContain('data-tab="details"');
+		expect(html).toContain('data-tab="preview"');
+	});
 
-  it("omits the preview tab when there is no query result", () => {
-    const html = renderPage({
-      detailsHtml: "<p>details</p>",
-      previewHtml: null,
-    });
-    expect(html).toContain("<p>details</p>");
-    expect(html).not.toContain('data-tab="preview"');
-  });
+	it("omits the preview tab when there is no query result", () => {
+		const html = renderPage({
+			detailsHtml: "<p>details</p>",
+			previewHtml: null,
+		});
+		expect(html).toContain("<p>details</p>");
+		expect(html).not.toContain('data-tab="preview"');
+	});
 
-  it("includes a script that listens for postMessage updates from the extension", () => {
-    const html = renderPage({
-      detailsHtml: "Loading...",
-      previewHtml: "Loading...",
-    });
-    expect(html).toContain('addEventListener("message"');
-    expect(html).toContain('data-tabpanel="details"');
-    expect(html).toContain('data-tabpanel="preview"');
-  });
+	it("includes a script that listens for postMessage updates from the extension", () => {
+		const html = renderPage({
+			detailsHtml: "Loading...",
+			previewHtml: "Loading...",
+		});
+		expect(html).toContain('addEventListener("message"');
+		expect(html).toContain('data-tabpanel="details"');
+		expect(html).toContain('data-tabpanel="preview"');
+	});
 
-  it("includes a script that handles separate details/preview message updates", () => {
-    const html = renderPage({
-      detailsHtml: "Loading...",
-      previewHtml: "Loading...",
-    });
-    expect(html).toContain('message.type === "details"');
-    expect(html).toContain('message.type === "preview"');
-  });
+	it("includes a script that handles separate details/preview message updates", () => {
+		const html = renderPage({
+			detailsHtml: "Loading...",
+			previewHtml: "Loading...",
+		});
+		expect(html).toContain('message.type === "details"');
+		expect(html).toContain('message.type === "preview"');
+	});
 
-  it("puts the Details tab before the Preview tab and makes Details active by default", () => {
-    const html = renderPage({
-      detailsHtml: "<p>details</p>",
-      previewHtml: "<table>preview</table>",
-    });
-    const detailsTabIndex = html.indexOf('data-tab="details"');
-    const previewTabIndex = html.indexOf('data-tab="preview"');
-    expect(detailsTabIndex).toBeGreaterThan(-1);
-    expect(previewTabIndex).toBeGreaterThan(-1);
-    expect(detailsTabIndex).toBeLessThan(previewTabIndex);
-    expect(html).toContain(
-      '<button class="bqls-tab active" data-tab="details">',
-    );
-    expect(html).toContain(
-      '<div class="bqls-tabpanel active" data-tabpanel="details">',
-    );
-  });
+	it("puts the Details tab before the Preview tab and makes Details active by default", () => {
+		const html = renderPage({
+			detailsHtml: "<p>details</p>",
+			previewHtml: "<table>preview</table>",
+		});
+		const detailsTabIndex = html.indexOf('data-tab="details"');
+		const previewTabIndex = html.indexOf('data-tab="preview"');
+		expect(detailsTabIndex).toBeGreaterThan(-1);
+		expect(previewTabIndex).toBeGreaterThan(-1);
+		expect(detailsTabIndex).toBeLessThan(previewTabIndex);
+		expect(html).toContain(
+			'<button class="bqls-tab active" data-tab="details">',
+		);
+		expect(html).toContain(
+			'<div class="bqls-tabpanel active" data-tabpanel="details">',
+		);
+	});
 });
 
 describe("buildVirtualDocumentHtml", () => {
-  it("renders contents and a query result table", () => {
-    const html = buildVirtualDocumentHtml(
-      ["## Job info"],
-      { columns: ["id"], data: [[1]] },
-    );
-    expect(html.detailsHtml).toBe("<h2>Job info</h2>");
-    expect(html.previewHtml).toBe(
-      '<table class="bqls-result"><thead><tr><th>id</th></tr></thead>' +
-        "<tbody><tr><td>1</td></tr></tbody></table>",
-    );
-  });
+	it("renders contents and a query result table", () => {
+		const html = buildVirtualDocumentHtml(["## Job info"], {
+			columns: ["id"],
+			data: [[1]],
+		});
+		expect(html.detailsHtml).toBe("<h2>Job info</h2>");
+		expect(html.previewHtml).toBe(
+			'<table class="bqls-result"><thead><tr><th>id</th></tr></thead>' +
+				"<tbody><tr><td>1</td></tr></tbody></table>",
+		);
+	});
 
-  it("shows a placeholder preview when there is no query result (DDL/DML jobs)", () => {
-    const html = buildVirtualDocumentHtml(["## Job info"], undefined);
-    expect(html.detailsHtml).toBe("<h2>Job info</h2>");
-    expect(html.previewHtml).toContain("No query result");
-  });
+	it("shows a placeholder preview when there is no query result (DDL/DML jobs)", () => {
+		const html = buildVirtualDocumentHtml(["## Job info"], undefined);
+		expect(html.detailsHtml).toBe("<h2>Job info</h2>");
+		expect(html.previewHtml).toContain("No query result");
+	});
 
-  it("treats missing contents as empty", () => {
-    const html = buildVirtualDocumentHtml(undefined, undefined);
-    expect(html.detailsHtml).toBe("");
-  });
+	it("treats missing contents as empty", () => {
+		const html = buildVirtualDocumentHtml(undefined, undefined);
+		expect(html.detailsHtml).toBe("");
+	});
 });
 
 describe("buildDetailsHtml", () => {
-  it("renders contents", () => {
-    expect(buildDetailsHtml(["## Job info"])).toBe("<h2>Job info</h2>");
-  });
+	it("renders contents", () => {
+		expect(buildDetailsHtml(["## Job info"])).toBe("<h2>Job info</h2>");
+	});
 
-  it("treats missing contents as empty", () => {
-    expect(buildDetailsHtml(undefined)).toBe("");
-    expect(buildDetailsHtml(null)).toBe("");
-  });
+	it("treats missing contents as empty", () => {
+		expect(buildDetailsHtml(undefined)).toBe("");
+		expect(buildDetailsHtml(null)).toBe("");
+	});
 
-  it("appends a schema table when schema is provided", () => {
-    const html = buildDetailsHtml(["## Job info"], [
-      { name: "id", type: "INTEGER" },
-    ]);
-    expect(html).toBe(
-      "<h2>Job info</h2>\n" +
-        '<table class="bqls-result"><thead><tr><th>Name</th><th>Type</th><th>Mode</th><th>Description</th></tr></thead>' +
-        "<tbody><tr><td>id</td><td>INTEGER</td><td>NULLABLE</td><td></td></tr></tbody></table>",
-    );
-  });
+	it("appends a schema table when schema is provided", () => {
+		const html = buildDetailsHtml(
+			["## Job info"],
+			[{ name: "id", type: "INTEGER" }],
+		);
+		expect(html).toBe(
+			"<h2>Job info</h2>\n" +
+				'<table class="bqls-result"><thead><tr><th>Name</th><th>Type</th><th>Mode</th><th>Description</th></tr></thead>' +
+				"<tbody><tr><td>id</td><td>INTEGER</td><td>NULLABLE</td><td></td></tr></tbody></table>",
+		);
+	});
 
-  it("omits the schema table when schema is empty", () => {
-    expect(buildDetailsHtml(["## Job info"], [])).toBe("<h2>Job info</h2>");
-  });
+	it("omits the schema table when schema is empty", () => {
+		expect(buildDetailsHtml(["## Job info"], [])).toBe("<h2>Job info</h2>");
+	});
 });
 
 describe("renderSchemaTable", () => {
-  it("renders a flat schema as a Name/Type/Mode/Description table", () => {
-    const html = renderSchemaTable([
-      { name: "id", type: "INTEGER", required: true, description: "primary key" },
-      { name: "name", type: "STRING" },
-    ]);
-    expect(html).toBe(
-      '<table class="bqls-result"><thead><tr><th>Name</th><th>Type</th><th>Mode</th><th>Description</th></tr></thead>' +
-        "<tbody>" +
-        "<tr><td>id</td><td>INTEGER</td><td>REQUIRED</td><td>primary key</td></tr>" +
-        "<tr><td>name</td><td>STRING</td><td>NULLABLE</td><td></td></tr>" +
-        "</tbody></table>",
-    );
-  });
+	it("renders a flat schema as a Name/Type/Mode/Description table", () => {
+		const html = renderSchemaTable([
+			{
+				name: "id",
+				type: "INTEGER",
+				required: true,
+				description: "primary key",
+			},
+			{ name: "name", type: "STRING" },
+		]);
+		expect(html).toBe(
+			'<table class="bqls-result"><thead><tr><th>Name</th><th>Type</th><th>Mode</th><th>Description</th></tr></thead>' +
+				"<tbody>" +
+				"<tr><td>id</td><td>INTEGER</td><td>REQUIRED</td><td>primary key</td></tr>" +
+				"<tr><td>name</td><td>STRING</td><td>NULLABLE</td><td></td></tr>" +
+				"</tbody></table>",
+		);
+	});
 
-  it("renders a repeated field's mode as REPEATED", () => {
-    const html = renderSchemaTable([
-      { name: "tags", type: "STRING", repeated: true },
-    ]);
-    expect(html).toContain("<td>REPEATED</td>");
-  });
+	it("renders a repeated field's mode as REPEATED", () => {
+		const html = renderSchemaTable([
+			{ name: "tags", type: "STRING", repeated: true },
+		]);
+		expect(html).toContain("<td>REPEATED</td>");
+	});
 
-  it("indents nested RECORD fields", () => {
-    const html = renderSchemaTable([
-      {
-        name: "address",
-        type: "RECORD",
-        fields: [
-          { name: "city", type: "STRING" },
-          { name: "zip", type: "STRING" },
-        ],
-      },
-    ]);
-    expect(html).toBe(
-      '<table class="bqls-result"><thead><tr><th>Name</th><th>Type</th><th>Mode</th><th>Description</th></tr></thead>' +
-        "<tbody>" +
-        "<tr><td>address</td><td>RECORD</td><td>NULLABLE</td><td></td></tr>" +
-        "<tr><td>&nbsp;&nbsp;city</td><td>STRING</td><td>NULLABLE</td><td></td></tr>" +
-        "<tr><td>&nbsp;&nbsp;zip</td><td>STRING</td><td>NULLABLE</td><td></td></tr>" +
-        "</tbody></table>",
-    );
-  });
+	it("indents nested RECORD fields", () => {
+		const html = renderSchemaTable([
+			{
+				name: "address",
+				type: "RECORD",
+				fields: [
+					{ name: "city", type: "STRING" },
+					{ name: "zip", type: "STRING" },
+				],
+			},
+		]);
+		expect(html).toBe(
+			'<table class="bqls-result"><thead><tr><th>Name</th><th>Type</th><th>Mode</th><th>Description</th></tr></thead>' +
+				"<tbody>" +
+				"<tr><td>address</td><td>RECORD</td><td>NULLABLE</td><td></td></tr>" +
+				"<tr><td>&nbsp;&nbsp;city</td><td>STRING</td><td>NULLABLE</td><td></td></tr>" +
+				"<tr><td>&nbsp;&nbsp;zip</td><td>STRING</td><td>NULLABLE</td><td></td></tr>" +
+				"</tbody></table>",
+		);
+	});
 });
 
 describe("buildPreviewHtml", () => {
-  it("renders a query result table", () => {
-    expect(buildPreviewHtml({ columns: ["id"], data: [[1]] })).toBe(
-      '<table class="bqls-result"><thead><tr><th>id</th></tr></thead>' +
-        "<tbody><tr><td>1</td></tr></tbody></table>",
-    );
-  });
+	it("renders a query result table", () => {
+		expect(buildPreviewHtml({ columns: ["id"], data: [[1]] })).toBe(
+			'<table class="bqls-result"><thead><tr><th>id</th></tr></thead>' +
+				"<tbody><tr><td>1</td></tr></tbody></table>",
+		);
+	});
 
-  it("shows a placeholder when there is no query result", () => {
-    expect(buildPreviewHtml(undefined)).toContain("No query result");
-    expect(buildPreviewHtml(null)).toContain("No query result");
-  });
+	it("shows a placeholder when there is no query result", () => {
+		expect(buildPreviewHtml(undefined)).toContain("No query result");
+		expect(buildPreviewHtml(null)).toContain("No query result");
+	});
 });
 
 describe("virtualDocumentTitle", () => {
-  it("builds a title for a table uri", () => {
-    expect(
-      virtualDocumentTitle("bqls://project/p/dataset/d/table/t"),
-    ).toBe("d.t");
-  });
+	it("builds a title for a table uri", () => {
+		expect(virtualDocumentTitle("bqls://project/p/dataset/d/table/t")).toBe(
+			"d.t",
+		);
+	});
 
-  it("builds a title for a job uri", () => {
-    expect(
-      virtualDocumentTitle("bqls://project/p/job/abc123/location/US"),
-    ).toBe("Job abc123");
-  });
+	it("builds a title for a job uri", () => {
+		expect(
+			virtualDocumentTitle("bqls://project/p/job/abc123/location/US"),
+		).toBe("Job abc123");
+	});
 
-  it("falls back to a generic title for an unrecognized uri", () => {
-    expect(virtualDocumentTitle("bqls://something/else")).toBe("bqls");
-  });
+	it("falls back to a generic title for an unrecognized uri", () => {
+		expect(virtualDocumentTitle("bqls://something/else")).toBe("bqls");
+	});
 });
 
 describe("renderQueryResultTable", () => {
-  it("renders columns and data as an html table", () => {
-    const html = renderQueryResultTable({
-      columns: ["id", "name"],
-      data: [[1, "alice"]],
-    });
-    expect(html).toBe(
-      '<table class="bqls-result"><thead><tr><th>id</th><th>name</th></tr></thead>' +
-        "<tbody><tr><td>1</td><td>alice</td></tr></tbody></table>",
-    );
-  });
+	it("renders columns and data as an html table", () => {
+		const html = renderQueryResultTable({
+			columns: ["id", "name"],
+			data: [[1, "alice"]],
+		});
+		expect(html).toBe(
+			'<table class="bqls-result"><thead><tr><th>id</th><th>name</th></tr></thead>' +
+				"<tbody><tr><td>1</td><td>alice</td></tr></tbody></table>",
+		);
+	});
 
-  it("uses schema to render nested cells", () => {
-    const html = renderQueryResultTable({
-      columns: ["tags"],
-      data: [[["a", "b"]]],
-      schema: [{ name: "tags", type: "STRING", repeated: true }],
-    });
-    expect(html).toBe(
-      '<table class="bqls-result"><thead><tr><th>tags</th></tr></thead>' +
-        "<tbody><tr><td>" +
-        '<details class="bqls-nested"><summary>[2]</summary><ul><li>a</li><li>b</li></ul></details>' +
-        "</td></tr></tbody></table>",
-    );
-  });
+	it("uses schema to render nested cells", () => {
+		const html = renderQueryResultTable({
+			columns: ["tags"],
+			data: [[["a", "b"]]],
+			schema: [{ name: "tags", type: "STRING", repeated: true }],
+		});
+		expect(html).toBe(
+			'<table class="bqls-result"><thead><tr><th>tags</th></tr></thead>' +
+				"<tbody><tr><td>" +
+				'<details class="bqls-nested"><summary>[2]</summary><ul><li>a</li><li>b</li></ul></details>' +
+				"</td></tr></tbody></table>",
+		);
+	});
 
-  it("adds a title attribute with the column description when available", () => {
-    const html = renderQueryResultTable({
-      columns: ["id"],
-      data: [[1]],
-      schema: [{ name: "id", type: "INTEGER", description: "primary key" }],
-    });
-    expect(html).toBe(
-      '<table class="bqls-result"><thead><tr><th title="primary key">id</th></tr></thead>' +
-        "<tbody><tr><td>1</td></tr></tbody></table>",
-    );
-  });
+	it("adds a title attribute with the column description when available", () => {
+		const html = renderQueryResultTable({
+			columns: ["id"],
+			data: [[1]],
+			schema: [{ name: "id", type: "INTEGER", description: "primary key" }],
+		});
+		expect(html).toBe(
+			'<table class="bqls-result"><thead><tr><th title="primary key">id</th></tr></thead>' +
+				"<tbody><tr><td>1</td></tr></tbody></table>",
+		);
+	});
 
-  it("omits the title attribute when there is no description", () => {
-    const html = renderQueryResultTable({
-      columns: ["id"],
-      data: [[1]],
-      schema: [{ name: "id", type: "INTEGER" }],
-    });
-    expect(html).toBe(
-      '<table class="bqls-result"><thead><tr><th>id</th></tr></thead>' +
-        "<tbody><tr><td>1</td></tr></tbody></table>",
-    );
-  });
+	it("omits the title attribute when there is no description", () => {
+		const html = renderQueryResultTable({
+			columns: ["id"],
+			data: [[1]],
+			schema: [{ name: "id", type: "INTEGER" }],
+		});
+		expect(html).toBe(
+			'<table class="bqls-result"><thead><tr><th>id</th></tr></thead>' +
+				"<tbody><tr><td>1</td></tr></tbody></table>",
+		);
+	});
 });

--- a/editors/vscode/src/webviewContent.ts
+++ b/editors/vscode/src/webviewContent.ts
@@ -1,94 +1,94 @@
 import { FieldSchema, MarkedString, QueryResult } from "./virtualDocument";
 
 export function escapeHtml(value: string): string {
-  return value
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#39;");
+	return value
+		.replace(/&/g, "&amp;")
+		.replace(/</g, "&lt;")
+		.replace(/>/g, "&gt;")
+		.replace(/"/g, "&quot;")
+		.replace(/'/g, "&#39;");
 }
 
 function withoutRepeated(schema: FieldSchema): FieldSchema {
-  return { ...schema, repeated: false };
+	return { ...schema, repeated: false };
 }
 
 export function renderCellValue(value: unknown, schema?: FieldSchema): string {
-  if (value === null || value === undefined) {
-    return '<span class="bqls-null">null</span>';
-  }
+	if (value === null || value === undefined) {
+		return '<span class="bqls-null">null</span>';
+	}
 
-  if (schema?.repeated) {
-    const items = value as unknown[];
-    const itemSchema = withoutRepeated(schema);
-    const inner = items
-      .map((item) => `<li>${renderCellValue(item, itemSchema)}</li>`)
-      .join("");
-    return `<details class="bqls-nested"><summary>[${items.length}]</summary><ul>${inner}</ul></details>`;
-  }
+	if (schema?.repeated) {
+		const items = value as unknown[];
+		const itemSchema = withoutRepeated(schema);
+		const inner = items
+			.map((item) => `<li>${renderCellValue(item, itemSchema)}</li>`)
+			.join("");
+		return `<details class="bqls-nested"><summary>[${items.length}]</summary><ul>${inner}</ul></details>`;
+	}
 
-  if (schema?.fields && schema.fields.length > 0) {
-    const record = value as unknown[];
-    const rows = schema.fields
-      .map(
-        (f, i) =>
-          `<tr><th>${escapeHtml(f.name)}</th><td>${renderCellValue(record[i], f)}</td></tr>`,
-      )
-      .join("");
-    return `<details class="bqls-nested"><summary>{…}</summary><table class="bqls-record">${rows}</table></details>`;
-  }
+	if (schema?.fields && schema.fields.length > 0) {
+		const record = value as unknown[];
+		const rows = schema.fields
+			.map(
+				(f, i) =>
+					`<tr><th>${escapeHtml(f.name)}</th><td>${renderCellValue(record[i], f)}</td></tr>`,
+			)
+			.join("");
+		return `<details class="bqls-nested"><summary>{…}</summary><table class="bqls-record">${rows}</table></details>`;
+	}
 
-  return escapeHtml(String(value));
+	return escapeHtml(String(value));
 }
 
 function renderInline(text: string): string {
-  return escapeHtml(text).replace(
-    /\[([^\]]+)\]\(([^)]+)\)/g,
-    (_match, label: string, url: string) => `<a href="${url}">${label}</a>`,
-  );
+	return escapeHtml(text).replace(
+		/\[([^\]]+)\]\(([^)]+)\)/g,
+		(_match, label: string, url: string) => `<a href="${url}">${label}</a>`,
+	);
 }
 
 function renderMarkdownText(text: string): string {
-  const parts: string[] = [];
-  let listItems: string[] = [];
+	const parts: string[] = [];
+	let listItems: string[] = [];
 
-  const flushList = () => {
-    if (listItems.length > 0) {
-      parts.push(`<ul>${listItems.join("")}</ul>`);
-      listItems = [];
-    }
-  };
+	const flushList = () => {
+		if (listItems.length > 0) {
+			parts.push(`<ul>${listItems.join("")}</ul>`);
+			listItems = [];
+		}
+	};
 
-  for (const line of text.split("\n")) {
-    const headingMatch = /^(#{1,6})\s+(.*)$/.exec(line);
-    const listMatch = /^\s*[-*]\s+(.*)$/.exec(line);
-    if (headingMatch) {
-      flushList();
-      const level = headingMatch[1].length;
-      parts.push(`<h${level}>${renderInline(headingMatch[2])}</h${level}>`);
-    } else if (listMatch) {
-      listItems.push(`<li>${renderInline(listMatch[1])}</li>`);
-    } else if (line.trim() === "") {
-      flushList();
-    } else {
-      flushList();
-      parts.push(`<p>${renderInline(line)}</p>`);
-    }
-  }
-  flushList();
-  return parts.join("");
+	for (const line of text.split("\n")) {
+		const headingMatch = /^(#{1,6})\s+(.*)$/.exec(line);
+		const listMatch = /^\s*[-*]\s+(.*)$/.exec(line);
+		if (headingMatch) {
+			flushList();
+			const level = headingMatch[1].length;
+			parts.push(`<h${level}>${renderInline(headingMatch[2])}</h${level}>`);
+		} else if (listMatch) {
+			listItems.push(`<li>${renderInline(listMatch[1])}</li>`);
+		} else if (line.trim() === "") {
+			flushList();
+		} else {
+			flushList();
+			parts.push(`<p>${renderInline(line)}</p>`);
+		}
+	}
+	flushList();
+	return parts.join("");
 }
 
 // Contents is only loosely Markdown, so skip a full parser and convert just
 // headings/bullet lists/links. Any other language is rendered as a code block.
 export function renderMarkedString(m: MarkedString): string {
-  if (typeof m === "string") {
-    return renderMarkdownText(m);
-  }
-  if (m.language === "markdown") {
-    return renderMarkdownText(m.value);
-  }
-  return `<pre><code>${escapeHtml(m.value)}</code></pre>`;
+	if (typeof m === "string") {
+		return renderMarkdownText(m);
+	}
+	if (m.language === "markdown") {
+		return renderMarkdownText(m.value);
+	}
+	return `<pre><code>${escapeHtml(m.value)}</code></pre>`;
 }
 
 const PAGE_STYLE = `
@@ -145,27 +145,27 @@ const PAGE_SCRIPT = `
 `;
 
 export function renderPage(params: {
-  detailsHtml: string;
-  previewHtml: string | null;
+	detailsHtml: string;
+	previewHtml: string | null;
 }): string {
-  const hasPreview = params.previewHtml !== null;
-  const defaultTab = "details";
+	const hasPreview = params.previewHtml !== null;
+	const defaultTab = "details";
 
-  const tabs = [
-    `<button class="bqls-tab active" data-tab="details">Details</button>`,
-    hasPreview
-      ? `<button class="bqls-tab" data-tab="preview">Preview</button>`
-      : "",
-  ].join("");
+	const tabs = [
+		`<button class="bqls-tab active" data-tab="details">Details</button>`,
+		hasPreview
+			? `<button class="bqls-tab" data-tab="preview">Preview</button>`
+			: "",
+	].join("");
 
-  const panels = [
-    `<div class="bqls-tabpanel active" data-tabpanel="details">${params.detailsHtml}</div>`,
-    hasPreview
-      ? `<div class="bqls-tabpanel" data-tabpanel="preview">${params.previewHtml}</div>`
-      : "",
-  ].join("");
+	const panels = [
+		`<div class="bqls-tabpanel active" data-tabpanel="details">${params.detailsHtml}</div>`,
+		hasPreview
+			? `<div class="bqls-tabpanel" data-tabpanel="preview">${params.previewHtml}</div>`
+			: "",
+	].join("");
 
-  return `<!DOCTYPE html>
+	return `<!DOCTYPE html>
 <html>
 <head>
 <meta charset="UTF-8">
@@ -180,14 +180,14 @@ export function renderPage(params: {
 }
 
 export function buildDetailsHtml(
-  contents: MarkedString[] | null | undefined,
-  schema?: FieldSchema[],
+	contents: MarkedString[] | null | undefined,
+	schema?: FieldSchema[],
 ): string {
-  const parts = (contents ?? []).map(renderMarkedString);
-  if (schema && schema.length > 0) {
-    parts.push(renderSchemaTable(schema));
-  }
-  return parts.join("\n");
+	const parts = (contents ?? []).map(renderMarkedString);
+	if (schema && schema.length > 0) {
+		parts.push(renderSchemaTable(schema));
+	}
+	return parts.join("\n");
 }
 
 // Renders a table schema (name/type/repeated/required/fields) as a
@@ -195,75 +195,81 @@ export function buildDetailsHtml(
 // Nested RECORD fields are indented with non-breaking spaces (matching
 // createBigQuerySchemaMarkdownTable on the server, for Hover).
 export function renderSchemaTable(schema: FieldSchema[]): string {
-  const rows = renderSchemaTableRows(schema, 0);
-  return `<table class="bqls-result"><thead><tr><th>Name</th><th>Type</th><th>Mode</th><th>Description</th></tr></thead><tbody>${rows}</tbody></table>`;
+	const rows = renderSchemaTableRows(schema, 0);
+	return `<table class="bqls-result"><thead><tr><th>Name</th><th>Type</th><th>Mode</th><th>Description</th></tr></thead><tbody>${rows}</tbody></table>`;
 }
 
 function renderSchemaTableRows(schema: FieldSchema[], depth: number): string {
-  const indent = "&nbsp;&nbsp;".repeat(depth);
-  return schema
-    .map((f) => {
-      const mode = f.repeated ? "REPEATED" : f.required ? "REQUIRED" : "NULLABLE";
-      const description = f.description ? escapeHtml(f.description) : "";
-      const row = `<tr><td>${indent}${escapeHtml(f.name)}</td><td>${escapeHtml(f.type)}</td><td>${mode}</td><td>${description}</td></tr>`;
-      const nested = f.fields ? renderSchemaTableRows(f.fields, depth + 1) : "";
-      return row + nested;
-    })
-    .join("");
+	const indent = "&nbsp;&nbsp;".repeat(depth);
+	return schema
+		.map((f) => {
+			const mode = f.repeated
+				? "REPEATED"
+				: f.required
+					? "REQUIRED"
+					: "NULLABLE";
+			const description = f.description ? escapeHtml(f.description) : "";
+			const row = `<tr><td>${indent}${escapeHtml(f.name)}</td><td>${escapeHtml(f.type)}</td><td>${mode}</td><td>${description}</td></tr>`;
+			const nested = f.fields ? renderSchemaTableRows(f.fields, depth + 1) : "";
+			return row + nested;
+		})
+		.join("");
 }
 
-export function buildPreviewHtml(result: QueryResult | null | undefined): string {
-  return result?.columns
-    ? renderQueryResultTable(result)
-    : '<p class="bqls-empty">No query result to preview.</p>';
+export function buildPreviewHtml(
+	result: QueryResult | null | undefined,
+): string {
+	return result?.columns
+		? renderQueryResultTable(result)
+		: '<p class="bqls-empty">No query result to preview.</p>';
 }
 
 // Shared between the initial synchronous render and the async
 // bqls/publishVirtualTextDocument notification handler, so both paths
 // build the same details/preview HTML from the same inputs.
 export function buildVirtualDocumentHtml(
-  contents: MarkedString[] | null | undefined,
-  result: QueryResult | null | undefined,
-  schema?: FieldSchema[],
+	contents: MarkedString[] | null | undefined,
+	result: QueryResult | null | undefined,
+	schema?: FieldSchema[],
 ): { detailsHtml: string; previewHtml: string } {
-  return {
-    detailsHtml: buildDetailsHtml(contents, schema),
-    previewHtml: buildPreviewHtml(result),
-  };
+	return {
+		detailsHtml: buildDetailsHtml(contents, schema),
+		previewHtml: buildPreviewHtml(result),
+	};
 }
 
 export function virtualDocumentTitle(uriString: string): string {
-  const tableMatch = /dataset\/([^/]+)\/table\/([^/]+)/.exec(uriString);
-  if (tableMatch) {
-    return `${tableMatch[1]}.${tableMatch[2]}`;
-  }
-  const jobMatch = /job\/([^/]+)/.exec(uriString);
-  if (jobMatch) {
-    return `Job ${jobMatch[1]}`;
-  }
-  return "bqls";
+	const tableMatch = /dataset\/([^/]+)\/table\/([^/]+)/.exec(uriString);
+	if (tableMatch) {
+		return `${tableMatch[1]}.${tableMatch[2]}`;
+	}
+	const jobMatch = /job\/([^/]+)/.exec(uriString);
+	if (jobMatch) {
+		return `Job ${jobMatch[1]}`;
+	}
+	return "bqls";
 }
 
 export function renderQueryResultTable(result: QueryResult): string {
-  const columns = result.columns ?? [];
-  const data = result.data ?? [];
-  const schema = result.schema ?? [];
+	const columns = result.columns ?? [];
+	const data = result.data ?? [];
+	const schema = result.schema ?? [];
 
-  const header = columns
-    .map((c, i) => {
-      const description = schema[i]?.description;
-      const title = description ? ` title="${escapeHtml(description)}"` : "";
-      return `<th${title}>${escapeHtml(c)}</th>`;
-    })
-    .join("");
-  const rows = data
-    .map((row) => {
-      const cells = row
-        .map((cell, i) => `<td>${renderCellValue(cell, schema[i])}</td>`)
-        .join("");
-      return `<tr>${cells}</tr>`;
-    })
-    .join("");
+	const header = columns
+		.map((c, i) => {
+			const description = schema[i]?.description;
+			const title = description ? ` title="${escapeHtml(description)}"` : "";
+			return `<th${title}>${escapeHtml(c)}</th>`;
+		})
+		.join("");
+	const rows = data
+		.map((row) => {
+			const cells = row
+				.map((cell, i) => `<td>${renderCellValue(cell, schema[i])}</td>`)
+				.join("");
+			return `<tr>${cells}</tr>`;
+		})
+		.join("");
 
-  return `<table class="bqls-result"><thead><tr>${header}</tr></thead><tbody>${rows}</tbody></table>`;
+	return `<table class="bqls-result"><thead><tr>${header}</tr></thead><tbody>${rows}</tbody></table>`;
 }

--- a/editors/vscode/tsconfig.json
+++ b/editors/vscode/tsconfig.json
@@ -1,15 +1,15 @@
 {
-  "compilerOptions": {
-    "module": "commonjs",
-    "target": "ES2022",
-    "lib": ["ES2022"],
-    "outDir": "out",
-    "rootDir": "src",
-    "sourceMap": true,
-    "strict": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "moduleResolution": "bundler"
-  },
-  "include": ["src/**/*.ts"]
+	"compilerOptions": {
+		"module": "commonjs",
+		"target": "ES2022",
+		"lib": ["ES2022"],
+		"outDir": "out",
+		"rootDir": "src",
+		"sourceMap": true,
+		"strict": true,
+		"esModuleInterop": true,
+		"skipLibCheck": true,
+		"moduleResolution": "bundler"
+	},
+	"include": ["src/**/*.ts"]
 }


### PR DESCRIPTION
## Summary
- Enable `formatter.enabled` in `editors/vscode/biome.json` (was `false`)
- Add `format` (check-only) and `format:fix` npm scripts to `editors/vscode/package.json`
- Reformat existing code with `biome format --write .` to resolve the formatting diff (indentation only, no behavior change)
- Add a `format check` step (`npm run format`) to the `Build and test` job in `.github/workflows/vscode.yml`

## Test plan
- [x] `npm run format` reports no diffs after the reformat
- [x] `npm run lint`
- [x] `npm run compile`
- [x] `npm run test`
- [x] `npm run build`

Closes #354